### PR TITLE
fix: toolchain needs to be nightly

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly"
+channel = "1.88.0"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
Without this, I can't compile the repo and hit 

```
$ cargo build
error: failed to download `base64ct v1.8.0`

Caused by:
  unable to get packages from source

Caused by:
  failed to parse manifest at `/home/kevin/.cargo/registry/src/index.crates.io-6f17d22bba15001f/base64ct-1.8.0/Cargo.toml`

Caused by:
  feature `edition2024` is required

  The package requires the Cargo feature called `edition2024`, but that feature is not stabilized in this version of Cargo (1.84.1 (66221abde 2024-11-19)).
  Consider trying a newer version of Cargo (this may require the nightly release).
  See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#edition-2024 for more information about the status of this feature.
```
