### PR TITLE
refactor(#49): make InitializationError more specific

### DIFF
--- a/src/confidential_key_derivation/protocol.rs
+++ b/src/confidential_key_derivation/protocol.rs
@@ -129,9 +129,10 @@ pub fn ckd(
     };
     // ensure the coordinator is a participant
     if !participants.contains(coordinator) {
-        return Err(InitializationError::BadParameters(format!(
-            "participant list must contain coordinator {coordinator:?}"
-        )));
+        return Err(InitializationError::MissingParticipant {
+            role: "coordinator",
+            participant: coordinator,
+        });
     };
 
     let comms = Comms::new();

--- a/src/confidential_key_derivation/protocol.rs
+++ b/src/confidential_key_derivation/protocol.rs
@@ -111,17 +111,14 @@ pub fn ckd(
 ) -> Result<impl Protocol<Output = CKDOutput>, InitializationError> {
     // not enough participants
     if participants.len() < 2 {
-        return Err(InitializationError::BadParameters(format!(
-            "participant count cannot be < 2, found: {}",
-            participants.len()
-        )));
+        return Err(InitializationError::NotEnoughParticipants {
+            participants: participants.len() as u32,
+        });
     };
 
     // kick out duplicates
     let Some(participants) = ParticipantList::new(participants) else {
-        return Err(InitializationError::BadParameters(
-            "Participants list contains duplicates".to_string(),
-        ));
+        return Err(InitializationError::DuplicateParticipants);
     };
 
     // ensure my presence in the participant list
@@ -270,5 +267,34 @@ mod test {
             "Keys should be equal"
         );
         Ok(())
+    }
+
+    #[test]
+    fn test_ckd_duplicate_participants() {
+        let participants = vec![
+            Participant::from(0u32),
+            Participant::from(1u32),
+            Participant::from(1u32),
+        ];
+        let coordinator = Participant::from(0u32);
+        let me = Participant::from(0u32);
+        let (_app_sk, app_pk) = Secp256K1Sha256::generate_nonce(&mut OsRng);
+        let app_pk = VerifyingKey::new(app_pk);
+        let f = Polynomial::<Secp256K1Sha256>::generate_polynomial(None, 2, &mut OsRng).unwrap();
+        let private_share = SigningShare::new(f.eval_at_participant(me).unwrap().0);
+        let app_id = b"test".to_vec();
+
+        let result = ckd(
+            &participants,
+            coordinator,
+            me,
+            private_share,
+            app_id,
+            app_pk,
+        );
+        match result {
+            Ok(_) => panic!("Expected an error, but got Ok"),
+            Err(err) => assert_eq!(err, InitializationError::DuplicateParticipants),
+        }
     }
 }

--- a/src/ecdsa/ot_based_ecdsa/sign.rs
+++ b/src/ecdsa/ot_based_ecdsa/sign.rs
@@ -78,15 +78,13 @@ pub fn sign(
     msg_hash: Scalar,
 ) -> Result<impl Protocol<Output = FullSignature>, InitializationError> {
     if participants.len() < 2 {
-        return Err(InitializationError::BadParameters(format!(
-            "participant count cannot be < 2, found: {}",
-            participants.len()
-        )));
+        return Err(InitializationError::NotEnoughParticipants {
+            participants: participants.len() as u32,
+        });
     };
 
-    let participants = ParticipantList::new(participants).ok_or_else(|| {
-        InitializationError::BadParameters("participant list cannot contain duplicates".to_string())
-    })?;
+    let participants =
+        ParticipantList::new(participants).ok_or(InitializationError::DuplicateParticipants)?;
 
     if !participants.contains(me) {
         return Err(InitializationError::BadParameters(

--- a/src/ecdsa/ot_based_ecdsa/triples/generation.rs
+++ b/src/ecdsa/ot_based_ecdsa/triples/generation.rs
@@ -1109,21 +1109,20 @@ pub fn generate_triple(
     threshold: usize,
 ) -> Result<impl Protocol<Output = TripleGenerationOutput>, InitializationError> {
     if participants.len() < 2 {
-        return Err(InitializationError::BadParameters(format!(
-            "participant count cannot be < 2, found: {}",
-            participants.len()
-        )));
+        return Err(InitializationError::NotEnoughParticipants {
+            participants: participants.len() as u32,
+        });
     };
     // Spec 1.1
     if threshold > participants.len() {
-        return Err(InitializationError::BadParameters(
-            "threshold must be <= participant count".to_string(),
-        ));
+        return Err(InitializationError::ThresholdTooLarge {
+            threshold: threshold as u32,
+            max: participants.len() as u32,
+        });
     }
 
-    let participants = ParticipantList::new(participants).ok_or_else(|| {
-        InitializationError::BadParameters("participant list cannot contain duplicates".to_string())
-    })?;
+    let participants =
+        ParticipantList::new(participants).ok_or(InitializationError::DuplicateParticipants)?;
 
     let ctx = Comms::new();
     let fut = do_generation(ctx.clone(), participants, me, threshold);
@@ -1137,21 +1136,20 @@ pub fn generate_triple_many<const N: usize>(
     threshold: usize,
 ) -> Result<impl Protocol<Output = TripleGenerationOutputMany>, InitializationError> {
     if participants.len() < 2 {
-        return Err(InitializationError::BadParameters(format!(
-            "participant count cannot be < 2, found: {}",
-            participants.len()
-        )));
+        return Err(InitializationError::NotEnoughParticipants {
+            participants: participants.len() as u32,
+        });
     };
     // Spec 1.1
     if threshold > participants.len() {
-        return Err(InitializationError::BadParameters(
-            "threshold must be <= participant count".to_string(),
-        ));
+        return Err(InitializationError::ThresholdTooLarge {
+            threshold: threshold as u32,
+            max: participants.len() as u32,
+        });
     }
 
-    let participants = ParticipantList::new(participants).ok_or_else(|| {
-        InitializationError::BadParameters("participant list cannot contain duplicates".to_string())
-    })?;
+    let participants =
+        ParticipantList::new(participants).ok_or(InitializationError::DuplicateParticipants)?;
 
     let ctx = Comms::new();
     let fut = do_generation_many::<N>(ctx.clone(), participants, me, threshold);

--- a/src/eddsa/sign.rs
+++ b/src/eddsa/sign.rs
@@ -228,9 +228,10 @@ pub fn sign(
     };
     // ensure the coordinator is a participant
     if !participants.contains(coordinator) {
-        return Err(InitializationError::BadParameters(format!(
-            "participant list must contain coordinator {coordinator:?}"
-        )));
+        return Err(InitializationError::MissingParticipant {
+            role: "coordinator",
+            participant: coordinator,
+        });
     };
 
     let comms = Comms::new();

--- a/src/eddsa/sign.rs
+++ b/src/eddsa/sign.rs
@@ -212,15 +212,12 @@ pub fn sign(
     message: Vec<u8>,
 ) -> Result<impl Protocol<Output = SignatureOutput>, InitializationError> {
     if participants.len() < 2 {
-        return Err(InitializationError::BadParameters(format!(
-            "participant count cannot be < 2, found: {}",
-            participants.len()
-        )));
+        return Err(InitializationError::NotEnoughParticipants {
+            participants: participants.len() as u32,
+        });
     };
     let Some(participants) = ParticipantList::new(participants) else {
-        return Err(InitializationError::BadParameters(
-            "Participants list contains duplicates".to_string(),
-        ));
+        return Err(InitializationError::DuplicateParticipants);
     };
 
     // ensure my presence in the participant list

--- a/src/generic_dkg.rs
+++ b/src/generic_dkg.rs
@@ -545,9 +545,10 @@ pub(crate) fn assert_keygen_invariants(
 
     // ensure my presence in the participant list
     if !participants.contains(me) {
-        return Err(InitializationError::BadParameters(format!(
-            "participant list must contain {me:?}"
-        )));
+        return Err(InitializationError::MissingParticipant {
+            role: "self",
+            participant: me,
+        });
     };
     Ok(participants)
 }
@@ -611,9 +612,10 @@ pub(crate) fn reshare_assertions<C: Ciphersuite>(
         ParticipantList::new(participants).ok_or(InitializationError::DuplicateParticipants)?;
 
     if !participants.contains(me) {
-        return Err(InitializationError::BadParameters(format!(
-            "participant list must contain {me:?}"
-        )));
+        return Err(InitializationError::MissingParticipant {
+            role: "self",
+            participant: me,
+        });
     }
 
     let old_participants =

--- a/src/generic_dkg.rs
+++ b/src/generic_dkg.rs
@@ -526,29 +526,28 @@ pub(crate) fn assert_keygen_invariants(
 ) -> Result<ParticipantList, InitializationError> {
     // need enough participants
     if participants.len() < 2 {
-        return Err(InitializationError::BadParameters(format!(
-            "participant count cannot be < 2, found: {}",
-            participants.len()
-        )));
+        return Err(InitializationError::NotEnoughParticipants {
+            participants: participants.len() as u32,
+        });
     };
 
     // validate threshold
     if threshold > participants.len() {
-        return Err(InitializationError::BadParameters(
-            "threshold must be <= participant count".to_string(),
-        ));
+        return Err(InitializationError::ThresholdTooLarge {
+            threshold: threshold as u32,
+            max: participants.len() as u32,
+        });
     }
 
     // ensure uniqueness of participants in the participant list
-    let participants = ParticipantList::new(participants).ok_or_else(|| {
-        InitializationError::BadParameters("participant list cannot contain duplicates".to_string())
-    })?;
+    let participants =
+        ParticipantList::new(participants).ok_or(InitializationError::DuplicateParticipants)?;
 
     // ensure my presence in the participant list
     if !participants.contains(me) {
-        return Err(InitializationError::BadParameters(
-            format!("participant list must contain {me:?}").to_string(),
-        ));
+        return Err(InitializationError::BadParameters(format!(
+            "participant list must contain {me:?}"
+        )));
     };
     Ok(participants)
 }
@@ -597,52 +596,40 @@ pub(crate) fn reshare_assertions<C: Ciphersuite>(
     old_participants: &[Participant],
 ) -> Result<(ParticipantList, ParticipantList), InitializationError> {
     if participants.len() < 2 {
-        return Err(InitializationError::BadParameters(format!(
-            "participant count cannot be < 2, found: {}",
-            participants.len()
-        )));
+        return Err(InitializationError::NotEnoughParticipants {
+            participants: participants.len() as u32,
+        });
     };
     if threshold > participants.len() {
-        return Err(InitializationError::BadParameters(
-            format!(
-                "new threshold {threshold:?} must be <= participant count {}",
-                participants.len()
-            )
-            .to_string(),
-        ));
+        return Err(InitializationError::ThresholdTooLarge {
+            threshold: threshold as u32,
+            max: participants.len() as u32,
+        });
     }
 
-    let participants = ParticipantList::new(participants).ok_or_else(|| {
-        InitializationError::BadParameters(
-            "new participant list cannot contain duplicates".to_string(),
-        )
-    })?;
+    let participants =
+        ParticipantList::new(participants).ok_or(InitializationError::DuplicateParticipants)?;
 
     if !participants.contains(me) {
-        return Err(InitializationError::BadParameters(
-            format!("participant list must contain {me:?}").to_string(),
-        ));
+        return Err(InitializationError::BadParameters(format!(
+            "participant list must contain {me:?}"
+        )));
     }
 
-    let old_participants = ParticipantList::new(old_participants).ok_or_else(|| {
-        InitializationError::BadParameters(
-            "old participant list cannot contain duplicates".to_string(),
-        )
-    })?;
+    let old_participants =
+        ParticipantList::new(old_participants).ok_or(InitializationError::DuplicateParticipants)?;
 
     if old_participants.intersection(&participants).len() < old_threshold {
-        return Err(InitializationError::BadParameters(
-            format!("not enough intersecting old/new participants {:?} to reconstruct private key for resharing with threshold bigger than old threshold {}",
-            old_participants.intersection(&participants),
-            old_threshold).to_string(),
-        ));
+        return Err(InitializationError::NotEnoughParticipantsForThreshold {
+            threshold: old_threshold as u32,
+            participants: old_participants.intersection(&participants).len() as u32,
+        });
     }
     // if me is not in the old participant set then ensure that old_signing_key is None
     if old_participants.contains(me) && old_signing_key.is_none() {
-        return Err(InitializationError::BadParameters(
-            format!("party {me:?} is present in the old participant list but provided no share")
-                .to_string(),
-        ));
+        return Err(InitializationError::BadParameters(format!(
+            "party {me:?} is present in the old participant list but provided no share"
+        )));
     }
     Ok((participants, old_participants))
 }

--- a/src/protocol/errors.rs
+++ b/src/protocol/errors.rs
@@ -75,6 +75,11 @@ impl From<Box<dyn error::Error + Send + Sync>> for ProtocolError {
 pub enum InitializationError {
     #[error("bad parameters: {0}")]
     BadParameters(String),
+    #[error("participant list must contain {role}: {participant:?}")]
+    MissingParticipant {
+        role: &'static str,
+        participant: Participant,
+    },
     #[error("participant list cannot contain duplicates")]
     DuplicateParticipants,
     #[error("Participant count cannot be < 2, found: {participants}")]

--- a/src/protocol/errors.rs
+++ b/src/protocol/errors.rs
@@ -71,8 +71,20 @@ impl From<Box<dyn error::Error + Send + Sync>> for ProtocolError {
 /// These are related to bad parameters for the protocol, and things like that.
 ///
 /// These are usually more recoverable than other protocol errors.
-#[derive(Debug, Error)]
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
 pub enum InitializationError {
     #[error("bad parameters: {0}")]
     BadParameters(String),
+    #[error("participant list cannot contain duplicates")]
+    DuplicateParticipants,
+    #[error("Participant count cannot be < 2, found: {participants}")]
+    NotEnoughParticipants { participants: u32 },
+    #[error("not enough intersecting old/new participants ({participants}) to reconstruct private key for resharing with threshold bigger than old threshold ({threshold})")]
+    NotEnoughParticipantsForThreshold { threshold: u32, participants: u32 },
+    #[error("threshold {threshold} is too small, it must be at least {min}")]
+    ThresholdTooSmall { threshold: u32, min: u32 },
+    #[error("threshold {threshold} is too large, it must be at most {max}")]
+    ThresholdTooLarge { threshold: u32, max: u32 },
+    #[error("participant has an invalid index")]
+    InvalidParticipantIndex,
 }


### PR DESCRIPTION
This commit refactors the `InitializationError` enum to be more specific about the error conditions. Instead of a generic `BadParameters(String)` error, we now have more specific errors like `DuplicateParticipants`, `NotEnoughParticipants`, `ThresholdTooSmall`, `ThresholdTooLarge`, and `InvalidParticipantIndex`.

This makes the code easier to debug and review, as the error type now carries more information about what went wrong.

This commit also adds a unit test to ensure that the correct error is returned when duplicate participants are provided.