### PR TITLE
Improving OT-based scheme documentation. Implementation rework. 

### DIFF
--- a/docs/ecdsa/signing.md
+++ b/docs/ecdsa/signing.md
@@ -60,17 +60,19 @@ $$
 
 # 3 Presigning
 
-In the setup phase, the parties generated a $t$ threshold sharing
-of the private key $x$, with the share of $\mathcal{P}_i$ being $x_i$.
-The parties also hold the public key $X = x \cdot G$.
-
-In two prior phases $\sigma \in \\{0, 1\\}$, a set of parties $\mathcal{P}_0^\sigma$ of size $N_0^\sigma$
-came together to generate a $t$ threshold sharing of triples $a^\sigma$, $b^\sigma$, $c^\sigma = a^\sigma b^\sigma$
-along with values $A^\sigma = a^\sigma \cdot G$, $B^\sigma = b^\sigma \cdot G$ and $C^\sigma = c^\sigma \cdot G$.
-
-In the current phase, a set of parties $\mathcal{P}_ 1 \subseteq \mathcal{P}_ 0^0 \cap \mathcal{P}^1_ 0$
-of size $N_1 \geq t$ wish to generate a threshold $t' = t$ sharing
+In this phase, a set of parties $\mathcal{P}_ 1 \subseteq \mathcal{P}_ 0^0 \cap \mathcal{P}^1_ 0$
+of size $N_1 \geq t$ wishes to generate a threshold $t' = t$ sharing
 of a pre-signature.
+
+The inputs to this phase are:
+
+1) The secret key share $x_i$.
+2) The public key $X$ corresponding to the master secret key $x$
+3) Two multiplicative (Beaver) triples private shares $(a_i, b_i, c_i)$ and $(k_i, d_i, e_i)$
+4) Two public triples commitments $(A, B, C)$ and $(K, D, E)$
+resp. associated to the (master) Beaver triples $(a, b, c)$ and $(k, d, e)$
+
+
 
 **Round 1:**
 
@@ -79,8 +81,8 @@ of a pre-signature.
 
 $$
 \begin{aligned}
-&k_i \gets a^0_i, &d_i \gets b^0_i,\quad &\text{kd}_i \gets c^0_i\cr
-&K \gets A^0, &D \gets B^0,\quad &\text{KD} \gets C^0\cr
+&k_i \gets a^0_i, &d_i \gets b^0_i,\quad &e_i \gets c^0_i\cr
+&K \gets A^0, &D \gets B^0,\quad &\text{E} \gets C^0\cr
 &a \gets a^1_i, &b \gets b^1_i,\quad &c \gets c^1_i\cr
 &A \gets A^1, &B \gets B^1,\quad &C \gets C^1\cr
 \end{aligned}
@@ -90,61 +92,67 @@ $$
 
 $$
 \begin{aligned}
-(k'_i, d_i, \text{kd}_i) &\gets \lambda(\mathcal{P}_1)_i \cdot (k_i, d_i, \text{kd}_i)\cr
+(k'_i, d_i, e_i) &\gets \lambda(\mathcal{P}_1)_i \cdot (k_i, d_i, e_i)\cr
 (a'_i, b'_i, c'_i) &\gets \lambda(\mathcal{P}_1)_i \cdot (a_i, b_i, c_i)\cr
 x'_i &\gets \lambda(\mathcal{P}_1)_i \cdot x_i\cr
 \end{aligned}
 $$
 
-4. $\star$ Each $P_i$ sends $\text{kd}_i$ to every other party.
+4. $\star$ Each $P_i$ sends $e_i$ to every other party.
 5. Each $P_i$ sets:
 
 $$
 \begin{aligned}
-&\text{ka}_i \gets k'_i + a'_i\cr
-&\text{xb}_i \gets x'_i + b'_i\cr
+&\alpha_i \gets k'_i + a'_i\cr
+&\beta_i \gets x'_i + b'_i\cr
 \end{aligned}
 $$
 
-6. $\star$ Each $P_i$ sends $\text{ka}_i$ and $\text{xb}_i$ to every other party.
+6. $\star$ Each $P_i$ sends $\alpha_i$ and $\beta_i$ to every other party.
 
 **Round 2:**
 
-1. $\bullet$ Each $P_i$ waits to receive $\text{kd}_j$ from each other $P_j$.
-2. Each $P_i$ sets $\text{kd} \gets \sum_j \text{kd}_j$.
-3. $\blacktriangle$ Each $P_i$ *asserts* that $\text{kd} \cdot G = \text{KD}$.
-4. $\bullet$ Each $P_i$ waits to receive $\text{ka}_j$ and $\text{xb}_j$ from from every other party $P_j$.
-5. Each $P_i$ sets $\text{ka} \gets \sum_j \text{ka}_j$ and $\text{xb} \gets \sum_j \text{xb}_j$.
+1. $\bullet$ Each $P_i$ waits to receive $e_j$ from each other $P_j$.
+2. Each $P_i$ sets $e \gets \sum_j e_j$.
+3. $\blacktriangle$ Each $P_i$ *asserts* that $e \cdot G = E$.
+4. $\bullet$ Each $P_i$ waits to receive $\alpha_j$ and $\text{xb}_j$ from from every other party $P_j$.
+5. Each $P_i$ sets $\alpha \gets \sum_j \alpha_j$ and $\beta \gets \sum_j \beta_j$.
 6. $\blacktriangle$ Each $P_i$ asserts that:
 
 $$
 \begin{aligned}
-\text{ka} \cdot G &= K + A\cr
-\text{xb} \cdot G &= X + B
+\alpha \cdot G &= K + A\quad \text{(in fact $\alpha = \sum_j \alpha_j =  \sum_j (k'_i + a'_i) = k + a$)}\cr
+\beta \cdot G &= X + B \quad \text{(in fact $\beta = \sum_j \beta_j =  \sum_j (x'_i + b'_i) = x + b$)}
 \end{aligned}
 $$
 
-7. Each $P_i$ sets: $R \gets \frac{1}{\text{kd}} \cdot D$.
-8. Each $P_i$ sets $\sigma_i \gets \text{ka} \cdot x_i - \text{xb} \cdot a_i + c_i$, which is already threshold shared.
+7. Each $P_i$ sets: $R \gets \frac{1}{e} \cdot D$. (Recall that Beaver triple $(k,d,e)$ is computed s.t. $e = k\cdot d$ )
+8. Each $P_i$ sets $\sigma_i \gets \alpha \cdot x_i - \beta \cdot a_i + c_i$, which is already threshold shared.
 
 **Output:**
-The output is the presignature $(R, k, \sigma)$, with $k$ and $\sigma$
-threshold shared as $k_1, \ldots$ and $\sigma_1, \ldots$.
-
+The output is the presignature $(R, k_i, \sigma_i)$
 # 4 Signing
 
-In the previous phase, a group of parties $\mathcal{P}_1$
-generate a presignature $(R, k, \sigma)$, with the values
-$k$, $\sigma$ being shared with a threshold of $t$.
+The inputs to this phase are:
+1) The presignature $(R, k_i, \sigma_i)$
+2) The public key $X$
+3) A "fresh" public source of entropy $\rho$
+4) A tweak $\epsilon$ used during key derivation
+5) The message hash $h= H(m)$
 
-In the signing phase, a group of parties $\mathcal{P}_2 \subseteq \mathcal{P}_1$ of size $\geq t$ consumes this presignature
-to sign a message $m$.
+**Rerandomization & Key Derivation:**
+1. Each $P_i$ derives a randomness $\delta = \mathsf{HKDF}(X, h, R, \rho)$
+2. Each $P_i$ rerandomizes the following elements:
+
+    * $R  \gets R^\delta$
+    * $\sigma_i \gets (\sigma_i + \epsilon \cdot k_i) \cdot \delta^{-1}$
+    * $k_i \gets k_i \cdot \delta^{-1}$
 
 **Round 1:**
 
 1. Each $P_i$ linearizes their share of $k$, setting $k_i \gets \lambda(\mathcal{P}_2)_i \cdot k_i$.
 2. Each $P_i$ linearizes their share of $\sigma$, setting $\sigma_i \gets \lambda(\mathcal{P}_2)_i \cdot \sigma_i$.
-3. Each $P_i$ sets $s_i \gets \text{Hash}(M) \cdot k_i + h(R) \sigma_i$.
+3. Each $P_i$ sets $s_i \gets h \cdot k_i + R_x \cdot \sigma_i$ where $R_x$ is the x coordinate of $R$
 4. $\star$ Each $P_i$ sends $s_i$ to every other party.
 
 **Round 2:**


### PR DESCRIPTION
This aims to improve on the original cait sith documentation of signing by using better notation and better representation to the inputs/outputs.
The documentation:
1) Adds the rerandomization part and key derivation (implementation should be resolved in #59 )
2) Simplifies notation, inputs and outputs
3) Reworks the Presigning algorithm to clearly separate the rounds
4) Reimplements the separation accordingly.