### PR TITLE
Simon/ot based ecdsa presign triples feature disable

### DIFF
--- a/src/confidential_key_derivation/protocol.rs
+++ b/src/confidential_key_derivation/protocol.rs
@@ -112,7 +112,7 @@ pub fn ckd(
     // not enough participants
     if participants.len() < 2 {
         return Err(InitializationError::NotEnoughParticipants {
-            participants: participants.len() as u32,
+            participants: participants.len(),
         });
     };
 

--- a/src/ecdsa/ot_based_ecdsa/presign.rs
+++ b/src/ecdsa/ot_based_ecdsa/presign.rs
@@ -23,14 +23,14 @@ pub fn presign(
 ) -> Result<impl Protocol<Output = PresignOutput>, InitializationError> {
     if participants.len() < 2 {
         return Err(InitializationError::NotEnoughParticipants {
-            participants: participants.len() as u32,
+            participants: participants.len(),
         });
     };
     // Spec 1.1
     if args.threshold > participants.len() {
         return Err(InitializationError::ThresholdTooLarge {
-            threshold: args.threshold as u32,
-            max: participants.len() as u32,
+            threshold: args.threshold,
+            max: participants.len(),
         });
     }
 

--- a/src/ecdsa/ot_based_ecdsa/sign.rs
+++ b/src/ecdsa/ot_based_ecdsa/sign.rs
@@ -26,7 +26,7 @@ pub fn sign(
 ) -> Result<impl Protocol<Output = FullSignature>, InitializationError> {
     if participants.len() < 2 {
         return Err(InitializationError::NotEnoughParticipants {
-            participants: participants.len() as u32,
+            participants: participants.len(),
         });
     };
 

--- a/src/ecdsa/ot_based_ecdsa/sign.rs
+++ b/src/ecdsa/ot_based_ecdsa/sign.rs
@@ -59,22 +59,22 @@ async fn do_sign(
     presignature: PresignOutput,
     msg_hash: Scalar,
 ) -> Result<FullSignature, ProtocolError> {
-    // Spec 1.1
+    // Linearize ki
     let lambda = participants.lagrange::<Secp256K1Sha256>(me)?;
     let k_i = lambda * presignature.k;
 
-    // Spec 1.2
+    // Linearize sigmai
     let sigma_i = lambda * presignature.sigma;
 
-    // Spec 1.3
+    // Compute si = h * ki + Rx * sigmai
     let r = x_coordinate(&presignature.big_r);
     let s_i = msg_hash * k_i + r * sigma_i;
 
-    // Spec 1.4
+    // Send si
     let wait0 = chan.next_waitpoint();
     chan.send_many(wait0, &s_i)?;
 
-    // Spec 2.1 + 2.2
+    // Receive sj
     let mut seen = ParticipantCounter::new(&participants);
     let mut s = s_i;
     seen.put(me);

--- a/src/ecdsa/ot_based_ecdsa/test.rs
+++ b/src/ecdsa/ot_based_ecdsa/test.rs
@@ -47,8 +47,6 @@ pub fn run_presign(
         let protocol = presign(
             &participant_list,
             p,
-            &participant_list,
-            p,
             PresignArguments {
                 triple0: (share0, pub0.clone()),
                 triple1: (share1, pub1.clone()),

--- a/src/ecdsa/ot_based_ecdsa/triples/generation.rs
+++ b/src/ecdsa/ot_based_ecdsa/triples/generation.rs
@@ -1110,14 +1110,14 @@ pub fn generate_triple(
 ) -> Result<impl Protocol<Output = TripleGenerationOutput>, InitializationError> {
     if participants.len() < 2 {
         return Err(InitializationError::NotEnoughParticipants {
-            participants: participants.len() as u32,
+            participants: participants.len(),
         });
     };
     // Spec 1.1
     if threshold > participants.len() {
         return Err(InitializationError::ThresholdTooLarge {
-            threshold: threshold as u32,
-            max: participants.len() as u32,
+            threshold: threshold,
+            max: participants.len(),
         });
     }
 
@@ -1137,14 +1137,14 @@ pub fn generate_triple_many<const N: usize>(
 ) -> Result<impl Protocol<Output = TripleGenerationOutputMany>, InitializationError> {
     if participants.len() < 2 {
         return Err(InitializationError::NotEnoughParticipants {
-            participants: participants.len() as u32,
+            participants: participants.len(),
         });
     };
     // Spec 1.1
     if threshold > participants.len() {
         return Err(InitializationError::ThresholdTooLarge {
-            threshold: threshold as u32,
-            max: participants.len() as u32,
+            threshold: threshold,
+            max: participants.len(),
         });
     }
 

--- a/src/ecdsa/ot_based_ecdsa/triples/generation.rs
+++ b/src/ecdsa/ot_based_ecdsa/triples/generation.rs
@@ -1116,7 +1116,7 @@ pub fn generate_triple(
     // Spec 1.1
     if threshold > participants.len() {
         return Err(InitializationError::ThresholdTooLarge {
-            threshold: threshold,
+            threshold,
             max: participants.len(),
         });
     }
@@ -1143,7 +1143,7 @@ pub fn generate_triple_many<const N: usize>(
     // Spec 1.1
     if threshold > participants.len() {
         return Err(InitializationError::ThresholdTooLarge {
-            threshold: threshold,
+            threshold,
             max: participants.len(),
         });
     }

--- a/src/eddsa/sign.rs
+++ b/src/eddsa/sign.rs
@@ -213,7 +213,7 @@ pub fn sign(
 ) -> Result<impl Protocol<Output = SignatureOutput>, InitializationError> {
     if participants.len() < 2 {
         return Err(InitializationError::NotEnoughParticipants {
-            participants: participants.len() as u32,
+            participants: participants.len(),
         });
     };
     let Some(participants) = ParticipantList::new(participants) else {

--- a/src/generic_dkg.rs
+++ b/src/generic_dkg.rs
@@ -527,15 +527,15 @@ pub(crate) fn assert_keygen_invariants(
     // need enough participants
     if participants.len() < 2 {
         return Err(InitializationError::NotEnoughParticipants {
-            participants: participants.len() as u32,
+            participants: participants.len(),
         });
     };
 
     // validate threshold
     if threshold > participants.len() {
         return Err(InitializationError::ThresholdTooLarge {
-            threshold: threshold as u32,
-            max: participants.len() as u32,
+            threshold: threshold,
+            max: participants.len(),
         });
     }
 
@@ -598,13 +598,13 @@ pub(crate) fn reshare_assertions<C: Ciphersuite>(
 ) -> Result<(ParticipantList, ParticipantList), InitializationError> {
     if participants.len() < 2 {
         return Err(InitializationError::NotEnoughParticipants {
-            participants: participants.len() as u32,
+            participants: participants.len(),
         });
     };
     if threshold > participants.len() {
         return Err(InitializationError::ThresholdTooLarge {
-            threshold: threshold as u32,
-            max: participants.len() as u32,
+            threshold: threshold,
+            max: participants.len() ,
         });
     }
 
@@ -623,8 +623,8 @@ pub(crate) fn reshare_assertions<C: Ciphersuite>(
 
     if old_participants.intersection(&participants).len() < old_threshold {
         return Err(InitializationError::NotEnoughParticipantsForThreshold {
-            threshold: old_threshold as u32,
-            participants: old_participants.intersection(&participants).len() as u32,
+            threshold: old_threshold,
+            participants: old_participants.intersection(&participants).len(),
         });
     }
     // if me is not in the old participant set then ensure that old_signing_key is None

--- a/src/generic_dkg.rs
+++ b/src/generic_dkg.rs
@@ -534,7 +534,7 @@ pub(crate) fn assert_keygen_invariants(
     // validate threshold
     if threshold > participants.len() {
         return Err(InitializationError::ThresholdTooLarge {
-            threshold: threshold,
+            threshold,
             max: participants.len(),
         });
     }
@@ -603,7 +603,7 @@ pub(crate) fn reshare_assertions<C: Ciphersuite>(
     };
     if threshold > participants.len() {
         return Err(InitializationError::ThresholdTooLarge {
-            threshold: threshold,
+            threshold,
             max: participants.len(),
         });
     }

--- a/src/generic_dkg.rs
+++ b/src/generic_dkg.rs
@@ -604,7 +604,7 @@ pub(crate) fn reshare_assertions<C: Ciphersuite>(
     if threshold > participants.len() {
         return Err(InitializationError::ThresholdTooLarge {
             threshold: threshold,
-            max: participants.len() ,
+            max: participants.len(),
         });
     }
 

--- a/src/protocol/errors.rs
+++ b/src/protocol/errors.rs
@@ -89,7 +89,10 @@ pub enum InitializationError {
     NotEnoughParticipants { participants: usize },
 
     #[error("not enough intersecting old/new participants ({participants}) to reconstruct private key for resharing with threshold bigger than old threshold ({threshold})")]
-    NotEnoughParticipantsForThreshold { threshold: usize, participants: usize },
+    NotEnoughParticipantsForThreshold {
+        threshold: usize,
+        participants: usize,
+    },
 
     #[error("threshold {threshold} is too small, it must be at least {min}")]
     ThresholdTooSmall { threshold: usize, min: usize },

--- a/src/protocol/errors.rs
+++ b/src/protocol/errors.rs
@@ -75,21 +75,28 @@ impl From<Box<dyn error::Error + Send + Sync>> for ProtocolError {
 pub enum InitializationError {
     #[error("bad parameters: {0}")]
     BadParameters(String),
+
     #[error("participant list must contain {role}: {participant:?}")]
     MissingParticipant {
         role: &'static str,
         participant: Participant,
     },
+
     #[error("participant list cannot contain duplicates")]
     DuplicateParticipants,
+
     #[error("Participant count cannot be < 2, found: {participants}")]
-    NotEnoughParticipants { participants: u32 },
+    NotEnoughParticipants { participants: usize },
+
     #[error("not enough intersecting old/new participants ({participants}) to reconstruct private key for resharing with threshold bigger than old threshold ({threshold})")]
-    NotEnoughParticipantsForThreshold { threshold: u32, participants: u32 },
+    NotEnoughParticipantsForThreshold { threshold: usize, participants: usize },
+
     #[error("threshold {threshold} is too small, it must be at least {min}")]
-    ThresholdTooSmall { threshold: u32, min: u32 },
+    ThresholdTooSmall { threshold: usize, min: usize },
+
     #[error("threshold {threshold} is too large, it must be at most {max}")]
-    ThresholdTooLarge { threshold: u32, max: u32 },
+    ThresholdTooLarge { threshold: usize, max: usize },
+
     #[error("participant has an invalid index")]
     InvalidParticipantIndex,
 }


### PR DESCRIPTION
Reimplements the separation according to the documentation in #62 .
The implementation and documentation both prevent running presign using two triples each coming from a different set of participants
Very important, the change in the API of presign now implies a change in the MPC API