### PR TITLE
Simon/rerandomization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -888,6 +888,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1530,6 +1539,7 @@ dependencies = [
  "frost-secp256k1",
  "futures",
  "hex",
+ "hkdf",
  "itertools 0.14.0",
  "k256",
  "keccak",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ frost-secp256k1 = { version = "2.1.0", default-features = false, features = [
 ] }
 futures = "0.3.31"
 hex = "0.4.3"
+hkdf = "0.12.4"
 itertools = "0.14.0"
 k256 = { version = "0.13.1", features = [
   "sha256",

--- a/src/ecdsa/mod.rs
+++ b/src/ecdsa/mod.rs
@@ -19,6 +19,7 @@ use crate::crypto::ciphersuite::{BytesOrder, Ciphersuite, ScalarSerializationFor
 use crate::participants::ParticipantList;
 
 pub type KeygenOutput = crate::KeygenOutput<Secp256K1Sha256>;
+pub type Tweak = crate::Tweak<Secp256K1Sha256>;
 pub type Scalar = <Secp256K1ScalarField as Field>::Scalar;
 pub type Element = <Secp256K1Group as Group>::Element;
 pub type CoefficientCommitment = frost_core::keys::CoefficientCommitment<Secp256K1Sha256>;
@@ -71,77 +72,97 @@ impl Signature {
     }
 }
 
-/// The following salt is picked by hashing with sha256
-/// "NEAR 6.4478$ 7:20pm CEST 2024-11-24"
-/// Based on [Krawczyk10] paper:
-/// ``[...] in most applications the extractor key (or salt) can be used
-/// repeatedly with many (independent) samples from the same source [...]''
-const SALT: [u8; 32] = [
-    0x32, 0x8a, 0x47, 0xc2, 0xb8, 0x79, 0x44, 0x45, 0x25, 0x5c, 0x16, 0x47, 0x60, 0x8d, 0xf5, 0xdb,
-    0x85, 0xc6, 0x8b, 0xb0, 0xe7, 0x17, 0x0a, 0xbe, 0xc5, 0x34, 0xdf, 0x27, 0x64, 0xa4, 0x58, 0x31,
-];
-
-/// Derives a random string from the public key, message hash, presignature R,
-/// set of participants and the entropy.
-///
-/// Outputs a random string computed as HKDF(entropy, pk, hash, R, participants)
+/// The arguments used to derive randomness used for presignature rerandomization.
+/// Presignature rerandomization has been thoroughly described in
+/// [GS21] https://eprint.iacr.org/2021/1330.pdf
 ///
 /// *** Warning ***
-/// Following [GS21] https://eprint.iacr.org/2021/1330.pdf, the entropy string
-/// should be freshly generated and unpredictable previous to calling this function
-pub fn derive_randomness(
-    pk: &AffinePoint,
-    msg_hash: &Scalar,
-    big_r: &AffinePoint,
-    participants: &ParticipantList,
-    entropy: [u8; 32],
-) -> Scalar {
-    // create a string containing (pk, msg_hash, big_r, sorted(participants))
-    let pk_encoded_point = pk.to_encoded_point(true);
-    let encoded_pk: &[u8] = pk_encoded_point.as_bytes();
-    let encoded_msg_hash: &[u8] = &msg_hash.to_bytes()[..];
-    let big_r_encoded_point = big_r.to_encoded_point(true);
-    let encoded_big_r: &[u8] = big_r_encoded_point.as_bytes();
-
-    // concatenate all the bytes
-    let mut concatenation = Vec::new();
-    concatenation.extend_from_slice(encoded_pk);
-    concatenation.extend_from_slice(encoded_msg_hash);
-    concatenation.extend_from_slice(encoded_big_r);
-    // Append each ParticipantId's
-    for participant in participants.participants() {
-        concatenation.extend_from_slice(&participant.bytes());
-    }
-
-    // initiate hkdf with the salt and with some `good' entropy
-    let hk = Hkdf::<sha3::Sha3_256>::new(Some(&SALT), &entropy);
-
-    let mut delta: Scalar = Scalar::ZERO;
-    // If the randomness created is 0 then we want to generate a new randomness
-    while bool::from(delta.is_zero()) {
-        // Generate randomization out of HKDF(entropy, pk, msg_hash, big_r, participants, nonce)
-        // where entropy is a public but unpredictable random string
-        // the nonce is a succession of appended ones of growing length depending on the number of times
-        // we enter into this loop
-        let mut okm = [0u8; 32];
-
-        // append an extra 0 at the end of the concatenation everytime delta hits zero
-        concatenation.extend_from_slice(&[0u8, 1]);
-        hk.expand(&concatenation, &mut okm).unwrap();
-
-        // derive the randomness delta
-        delta = Scalar::from_repr(okm.into()).unwrap_or(
-            // if delta falls outside the field
-            // probability is negligible: in the order of 1/2^224
-            Scalar::ZERO,
-        )
-    }
-    delta
+/// Following [GS21] https://eprint.iacr.org/2021/1330.pdf, the entropy should
+/// be public, freshly generated, and unpredictable.
+pub struct RerandomizationArguments<'a> {
+    pub pk: &'a AffinePoint,
+    pub msg_hash: &'a Scalar,
+    pub big_r: &'a AffinePoint,
+    pub participants: &'a ParticipantList,
+    /// Fresh, Unpredictable, and Public source of entropy
+    pub entropy: [u8; 32],
 }
 
-/// Derives a public key from a tweak and a master public key: tweak.G + X
-pub fn derive_public_key(public_key: AffinePoint, tweak: Scalar) -> AffinePoint {
-    (AffinePoint::GENERATOR * tweak + public_key).to_affine()
+impl<'a> RerandomizationArguments<'a> {
+    /// The following salt is picked by hashing with sha256
+    /// "NEAR 6.4478$ 7:20pm CEST 2024-11-24"
+    /// Based on [Krawczyk10] paper:
+    /// ``[...] in most applications the extractor key (or salt) can be used
+    /// repeatedly with many (independent) samples from the same source [...]''
+    const SALT: [u8; 32] = [
+        0x32, 0x8a, 0x47, 0xc2, 0xb8, 0x79, 0x44, 0x45, 0x25, 0x5c, 0x16, 0x47, 0x60, 0x8d, 0xf5,
+        0xdb, 0x85, 0xc6, 0x8b, 0xb0, 0xe7, 0x17, 0x0a, 0xbe, 0xc5, 0x34, 0xdf, 0x27, 0x64, 0xa4,
+        0x58, 0x31,
+    ];
+
+    pub fn new(
+        pk: &'a AffinePoint,
+        msg_hash: &'a Scalar,
+        big_r: &'a AffinePoint,
+        participants: &'a ParticipantList,
+        entropy: [u8; 32],
+    ) -> RerandomizationArguments<'a> {
+        RerandomizationArguments {
+            pk,
+            msg_hash,
+            big_r,
+            participants,
+            entropy,
+        }
+    }
+
+    /// Derives a random string from the public key, message hash, presignature R,
+    /// set of participants and the entropy.
+    ///
+    /// Outputs a random string computed as HKDF(entropy, pk, hash, R, participants)
+    pub fn derive_randomness(self) -> Scalar {
+        // create a string containing (pk, msg_hash, big_r, sorted(participants))
+        let pk_encoded_point = self.pk.to_encoded_point(true);
+        let encoded_pk: &[u8] = pk_encoded_point.as_bytes();
+        let encoded_msg_hash: &[u8] = &self.msg_hash.to_bytes()[..];
+        let big_r_encoded_point = self.big_r.to_encoded_point(true);
+        let encoded_big_r: &[u8] = big_r_encoded_point.as_bytes();
+
+        // concatenate all the bytes
+        let mut concatenation = Vec::new();
+        concatenation.extend_from_slice(encoded_pk);
+        concatenation.extend_from_slice(encoded_msg_hash);
+        concatenation.extend_from_slice(encoded_big_r);
+        // Append each ParticipantId's
+        for participant in self.participants.participants() {
+            concatenation.extend_from_slice(&participant.bytes());
+        }
+
+        // initiate hkdf with the salt and with some `good' entropy
+        let hk = Hkdf::<sha3::Sha3_256>::new(Some(&Self::SALT), &self.entropy);
+
+        let mut delta = Scalar::ZERO;
+        // If the randomness created is 0 then we want to generate a new randomness
+        while bool::from(delta.is_zero()) {
+            // Generate randomization out of HKDF(entropy, pk, msg_hash, big_r, participants, nonce)
+            // where entropy is a public but unpredictable random string
+            // the nonce is a succession of appended ones of growing length depending on the number of times
+            // we enter into this loop
+            let mut okm = [0u8; 32];
+
+            // append an extra 0 at the end of the concatenation everytime delta hits zero
+            concatenation.extend_from_slice(&[0u8, 1]);
+            hk.expand(&concatenation, &mut okm).unwrap();
+
+            // derive the randomness delta
+            delta = Scalar::from_repr(okm.into()).unwrap_or(
+                // if delta falls outside the field
+                // probability is negligible: in the order of 1/2^224
+                Scalar::ZERO,
+            )
+        }
+        delta
+    }
 }
 
 #[cfg(test)]
@@ -235,6 +256,7 @@ mod test_verify {
         let sk = SigningKey::random(&mut OsRng);
         let pk = *VerifyingKey::from(sk).as_affine();
         let (_, big_r) = <C>::generate_nonce(&mut OsRng);
+        let big_r = big_r.to_affine();
 
         let msg_hash = Scalar::generate_vartime(&mut OsRng);
         // Generate unique ten ParticipantId values
@@ -244,11 +266,17 @@ mod test_verify {
         let mut entropy: [u8; 32] = [0u8; 32];
         OsRng.fill_bytes(&mut entropy);
 
-        let delta = derive_randomness(&pk, &msg_hash, &big_r.to_affine(), &participants, entropy);
-
+        let args = RerandomizationArguments::new(
+            &pk,
+            &msg_hash,
+            &big_r,
+            &participants,
+            entropy
+        );
+        let delta = args.derive_randomness();
         (
             pk,
-            big_r.to_affine(),
+            big_r,
             msg_hash,
             participants,
             entropy,
@@ -262,15 +290,16 @@ mod test_verify {
         let (_, big_r, msg_hash, participants, entropy, delta) =
             compute_random_outputs(num_participants);
         // different pk
-        let (_, pk_prime) = <C>::generate_nonce(&mut OsRng);
-
-        let delta_prime = derive_randomness(
-            &pk_prime.to_affine(),
+        let (_, pk) = <C>::generate_nonce(&mut OsRng);
+        let pk = pk.to_affine();
+        let args = RerandomizationArguments::new(
+            &pk,
             &msg_hash,
             &big_r,
             &participants,
-            entropy,
+            entropy
         );
+        let delta_prime = args.derive_randomness();
         assert!(delta != delta_prime);
     }
 
@@ -278,11 +307,16 @@ mod test_verify {
     fn test_different_msg_hash() {
         let num_participants = 10;
         let (pk, big_r, _, participants, entropy, delta) = compute_random_outputs(num_participants);
-
+        let msg_hash = Scalar::generate_vartime(&mut OsRng);
         // different msg_hash
-        let msg_hash_prime = Scalar::generate_vartime(&mut OsRng);
-        let delta_prime = derive_randomness(&pk, &msg_hash_prime, &big_r, &participants, entropy);
-
+        let args = RerandomizationArguments::new(
+            &pk,
+            &msg_hash,
+            &big_r,
+            &participants,
+            entropy
+        );
+        let delta_prime = args.derive_randomness();
         assert!(delta != delta_prime);
     }
 
@@ -292,14 +326,16 @@ mod test_verify {
         let (pk, _, msg_hash, participants, entropy, delta) =
             compute_random_outputs(num_participants);
         // different big_r
-        let (_, big_r_prime) = <C>::generate_nonce(&mut OsRng);
-        let delta_prime = derive_randomness(
+        let (_, big_r) = <C>::generate_nonce(&mut OsRng);
+        let big_r = big_r.to_affine();
+        let args = RerandomizationArguments::new(
             &pk,
             &msg_hash,
-            &big_r_prime.to_affine(),
+            &big_r,
             &participants,
-            entropy,
+            entropy
         );
+        let delta_prime = args.derive_randomness();
         assert!(delta != delta_prime);
     }
 
@@ -310,8 +346,14 @@ mod test_verify {
         // different participants set
         let participants = generate_participants_with_random_ids(num_participants);
         let participants = ParticipantList::new(&participants).unwrap();
-
-        let delta_prime = derive_randomness(&pk, &msg_hash, &big_r, &participants, entropy);
+        let args = RerandomizationArguments::new(
+            &pk,
+            &msg_hash,
+            &big_r,
+            &participants,
+            entropy
+        );
+        let delta_prime = args.derive_randomness();
         assert!(delta != delta_prime);
     }
 
@@ -324,8 +366,14 @@ mod test_verify {
         // different entropy
         let mut entropy: [u8; 32] = [0u8; 32];
         OsRng.fill_bytes(&mut entropy);
-
-        let delta_prime = derive_randomness(&pk, &msg_hash, &big_r, &participants, entropy);
+        let args = RerandomizationArguments::new(
+            &pk,
+            &msg_hash,
+            &big_r,
+            &participants,
+            entropy
+        );
+        let delta_prime = args.derive_randomness();
         assert!(delta != delta_prime);
     }
 
@@ -341,8 +389,14 @@ mod test_verify {
         let mut participants = participants.participants().to_vec();
         participants.shuffle(&mut rng);
         let participants = ParticipantList::new(&participants).unwrap();
-
-        let delta_prime = derive_randomness(&pk, &msg_hash, &big_r, &participants, entropy);
+        let args = RerandomizationArguments::new(
+            &pk,
+            &msg_hash,
+            &big_r,
+            &participants,
+            entropy
+        );
+        let delta_prime = args.derive_randomness();
         assert!(delta == delta_prime);
     }
 }

--- a/src/ecdsa/mod.rs
+++ b/src/ecdsa/mod.rs
@@ -120,7 +120,7 @@ impl<'a> RerandomizationArguments<'a> {
     /// set of participants and the entropy.
     ///
     /// Outputs a random string computed as HKDF(entropy, pk, hash, R, participants)
-    pub fn derive_randomness(self) -> Scalar {
+    pub fn derive_randomness(&self) -> Scalar {
         // create a string containing (pk, msg_hash, big_r, sorted(participants))
         let pk_encoded_point = self.pk.to_encoded_point(true);
         let encoded_pk: &[u8] = pk_encoded_point.as_bytes();

--- a/src/ecdsa/mod.rs
+++ b/src/ecdsa/mod.rs
@@ -266,22 +266,9 @@ mod test_verify {
         let mut entropy: [u8; 32] = [0u8; 32];
         OsRng.fill_bytes(&mut entropy);
 
-        let args = RerandomizationArguments::new(
-            &pk,
-            &msg_hash,
-            &big_r,
-            &participants,
-            entropy
-        );
+        let args = RerandomizationArguments::new(&pk, &msg_hash, &big_r, &participants, entropy);
         let delta = args.derive_randomness();
-        (
-            pk,
-            big_r,
-            msg_hash,
-            participants,
-            entropy,
-            delta,
-        )
+        (pk, big_r, msg_hash, participants, entropy, delta)
     }
 
     #[test]
@@ -292,13 +279,7 @@ mod test_verify {
         // different pk
         let (_, pk) = <C>::generate_nonce(&mut OsRng);
         let pk = pk.to_affine();
-        let args = RerandomizationArguments::new(
-            &pk,
-            &msg_hash,
-            &big_r,
-            &participants,
-            entropy
-        );
+        let args = RerandomizationArguments::new(&pk, &msg_hash, &big_r, &participants, entropy);
         let delta_prime = args.derive_randomness();
         assert!(delta != delta_prime);
     }
@@ -309,13 +290,7 @@ mod test_verify {
         let (pk, big_r, _, participants, entropy, delta) = compute_random_outputs(num_participants);
         let msg_hash = Scalar::generate_vartime(&mut OsRng);
         // different msg_hash
-        let args = RerandomizationArguments::new(
-            &pk,
-            &msg_hash,
-            &big_r,
-            &participants,
-            entropy
-        );
+        let args = RerandomizationArguments::new(&pk, &msg_hash, &big_r, &participants, entropy);
         let delta_prime = args.derive_randomness();
         assert!(delta != delta_prime);
     }
@@ -328,13 +303,7 @@ mod test_verify {
         // different big_r
         let (_, big_r) = <C>::generate_nonce(&mut OsRng);
         let big_r = big_r.to_affine();
-        let args = RerandomizationArguments::new(
-            &pk,
-            &msg_hash,
-            &big_r,
-            &participants,
-            entropy
-        );
+        let args = RerandomizationArguments::new(&pk, &msg_hash, &big_r, &participants, entropy);
         let delta_prime = args.derive_randomness();
         assert!(delta != delta_prime);
     }
@@ -346,13 +315,7 @@ mod test_verify {
         // different participants set
         let participants = generate_participants_with_random_ids(num_participants);
         let participants = ParticipantList::new(&participants).unwrap();
-        let args = RerandomizationArguments::new(
-            &pk,
-            &msg_hash,
-            &big_r,
-            &participants,
-            entropy
-        );
+        let args = RerandomizationArguments::new(&pk, &msg_hash, &big_r, &participants, entropy);
         let delta_prime = args.derive_randomness();
         assert!(delta != delta_prime);
     }
@@ -366,13 +329,7 @@ mod test_verify {
         // different entropy
         let mut entropy: [u8; 32] = [0u8; 32];
         OsRng.fill_bytes(&mut entropy);
-        let args = RerandomizationArguments::new(
-            &pk,
-            &msg_hash,
-            &big_r,
-            &participants,
-            entropy
-        );
+        let args = RerandomizationArguments::new(&pk, &msg_hash, &big_r, &participants, entropy);
         let delta_prime = args.derive_randomness();
         assert!(delta != delta_prime);
     }
@@ -389,13 +346,7 @@ mod test_verify {
         let mut participants = participants.participants().to_vec();
         participants.shuffle(&mut rng);
         let participants = ParticipantList::new(&participants).unwrap();
-        let args = RerandomizationArguments::new(
-            &pk,
-            &msg_hash,
-            &big_r,
-            &participants,
-            entropy
-        );
+        let args = RerandomizationArguments::new(&pk, &msg_hash, &big_r, &participants, entropy);
         let delta_prime = args.derive_randomness();
         assert!(delta == delta_prime);
     }

--- a/src/ecdsa/ot_based_ecdsa/mod.rs
+++ b/src/ecdsa/ot_based_ecdsa/mod.rs
@@ -63,14 +63,12 @@ impl RerandomizedPresignOutput {
             return Err(ProtocolError::IncompatibleRerandomizationInputs);
         }
         let delta = args.derive_randomness();
-        let inv_delta = delta.invert();
-        if inv_delta.is_none().into() {
-            return Err(ProtocolError::AssertionFailed(
-                "expected a non-zero randomness".to_string(),
-            ));
+        if delta.is_zero().into() {
+            return Err(ProtocolError::ZeroScalar);
         }
-        // cannot fail due to the previous check
-        let inv_delta = inv_delta.unwrap();
+
+        // cannot be zero due to the previous check
+        let inv_delta = delta.invert().unwrap();
 
         // delta . R
         let rerandomized_big_r = presignature.big_r * delta;

--- a/src/ecdsa/ot_based_ecdsa/mod.rs
+++ b/src/ecdsa/ot_based_ecdsa/mod.rs
@@ -1,20 +1,16 @@
-use crate::ecdsa::{AffinePoint, KeygenOutput, Scalar};
-use serde::{Deserialize, Serialize};
-use triples::{TriplePub, TripleShare};
+pub mod presign;
+pub mod sign;
+pub mod triples;
 
-/// The output of the presigning protocol.
-///
-/// This output is basically all the parts of the signature that we can perform
-/// without knowing the message.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct PresignOutput {
-    /// The public nonce commitment.
-    pub big_r: AffinePoint,
-    /// Our share of the nonce value.
-    pub k: Scalar,
-    /// Our share of the sigma value.
-    pub sigma: Scalar,
-}
+#[cfg(test)]
+mod test;
+
+use crate::ecdsa::{
+    ot_based_ecdsa::triples::{TriplePub, TripleShare},
+    AffinePoint, KeygenOutput, RerandomizationArguments, Scalar, Tweak,
+};
+use crate::protocol::errors::ProtocolError;
+use serde::{Deserialize, Serialize};
 
 /// The arguments needed to create a presignature.
 #[derive(Debug, Clone)]
@@ -30,9 +26,76 @@ pub struct PresignArguments {
     pub threshold: usize,
 }
 
-pub mod presign;
-pub mod sign;
-pub mod triples;
+/// The output of the presigning protocol.
+///
+/// This output is basically all the parts of the signature that we can perform
+/// without knowing the message.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PresignOutput {
+    /// The public nonce commitment.
+    pub big_r: AffinePoint,
+    /// Our share of the nonce value.
+    pub k: Scalar,
+    /// Our share of the sigma value.
+    pub sigma: Scalar,
+}
 
-#[cfg(test)]
-mod test;
+/// The output of the presigning protocol.
+/// Contains the signature precomputed elements
+/// independently of the message
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RerandomizedPresignOutput {
+    /// The rerandomized public nonce commitment.
+    pub big_r: AffinePoint,
+    /// Our rerandomized share of the nonce value.
+    pub k: Scalar,
+    /// Our rerandomized share of the sigma value.
+    pub sigma: Scalar,
+}
+
+impl RerandomizedPresignOutput {
+    pub fn new(
+        presignature: PresignOutput,
+        tweak: Tweak,
+        args: RerandomizationArguments,
+    ) -> Result<Self, ProtocolError> {
+        if presignature.big_r != *args.big_r {
+            return Err(ProtocolError::IncompatibleRerandomizationInputs);
+        }
+        let delta = args.derive_randomness();
+        let inv_delta = delta.invert();
+        if inv_delta.is_none().into() {
+            return Err(ProtocolError::AssertionFailed(
+                "expected a non-zero randomness".to_string(),
+            ));
+        }
+        // cannot fail due to the previous check
+        let inv_delta = inv_delta.unwrap();
+
+        // delta . R
+        let rerandomized_big_r = presignature.big_r * delta;
+
+        //  (sigma + tweak * k) * delta^{-1}
+        let rerandomized_sigma = (presignature.sigma + tweak.value() * presignature.k) * inv_delta;
+
+        // k * delta^{-1}
+        let rerandomized_k = presignature.k * inv_delta;
+
+        Ok(RerandomizedPresignOutput {
+            big_r: rerandomized_big_r.into(),
+            k: rerandomized_k,
+            sigma: rerandomized_sigma,
+        })
+    }
+
+    #[cfg(test)]
+    /// Outputs the same elements as in the PresignatureOutput
+    /// Used for testing the core schemes without rerandomization
+    pub fn new_without_rerandomization(presignature: &PresignOutput) -> Self {
+        RerandomizedPresignOutput {
+            big_r: presignature.big_r,
+            k: presignature.k,
+            sigma: presignature.sigma,
+        }
+    }
+}

--- a/src/ecdsa/ot_based_ecdsa/mod.rs
+++ b/src/ecdsa/ot_based_ecdsa/mod.rs
@@ -55,9 +55,9 @@ pub struct RerandomizedPresignOutput {
 
 impl RerandomizedPresignOutput {
     pub fn new(
-        presignature: PresignOutput,
-        tweak: Tweak,
-        args: RerandomizationArguments,
+        presignature: &PresignOutput,
+        tweak: &Tweak,
+        args: &RerandomizationArguments,
     ) -> Result<Self, ProtocolError> {
         if presignature.big_r != *args.big_r {
             return Err(ProtocolError::IncompatibleRerandomizationInputs);

--- a/src/ecdsa/ot_based_ecdsa/sign.rs
+++ b/src/ecdsa/ot_based_ecdsa/sign.rs
@@ -114,10 +114,10 @@ async fn do_sign(
 
 #[cfg(test)]
 mod test {
-    use super::{x_coordinate, RerandomizedPresignOutput};
+    use super::x_coordinate;
     use crate::{
         ecdsa::{
-            ot_based_ecdsa::{test::run_sign, PresignOutput},
+            ot_based_ecdsa::{test::run_sign_without_rerandomization, PresignOutput},
             Polynomial,
         },
         test::generate_participants,
@@ -153,12 +153,10 @@ mod test {
                 k: g.eval_at_participant(*p)?.0,
                 sigma: h.eval_at_participant(*p)?.0,
             };
-            let presignature =
-                RerandomizedPresignOutput::new_without_rerandomization(&presignature);
             participants_presign.push((*p, presignature));
         }
 
-        let result = run_sign(participants_presign, public_key, msg)?;
+        let result = run_sign_without_rerandomization(participants_presign, public_key, msg)?;
         let sig = &result[0].1;
         let sig = ecdsa::Signature::from_scalars(x_coordinate(&sig.big_r), sig.s)?;
         VerifyingKey::from(&PublicKey::from_affine(public_key.to_affine())?).verify(msg, &sig)?;

--- a/src/ecdsa/ot_based_ecdsa/test.rs
+++ b/src/ecdsa/ot_based_ecdsa/test.rs
@@ -4,7 +4,6 @@ use super::{
     triples::{test::deal, TriplePub, TripleShare},
     PresignArguments, PresignOutput,
 };
-use crate::ecdsa::{Element, KeygenOutput, Secp256K1Sha256, Signature};
 use crate::protocol::{run_protocol, Participant, Protocol};
 use crate::test::{
     assert_public_key_invariant, generate_participants, generate_participants_with_random_ids,
@@ -13,7 +12,14 @@ use crate::test::{
 use crate::{
     crypto::hash::test::scalar_hash_secp256k1, ecdsa::ot_based_ecdsa::RerandomizedPresignOutput,
 };
-use rand_core::OsRng;
+use crate::{
+    ecdsa::{
+        Element, KeygenOutput, ParticipantList, RerandomizationArguments, Secp256K1Sha256,
+        Signature,
+    },
+    Tweak,
+};
+use rand_core::{OsRng, RngCore};
 use std::error::Error;
 
 /// Runs signing by calling the generic run_sign function from crate::test
@@ -44,6 +50,57 @@ pub fn run_sign_without_rerandomization(
                 .map(|sig| Box::new(sig) as Box<dyn Protocol<Output = Signature>>)
         },
     )
+}
+
+type SigWithRerand = (Tweak<Secp256K1Sha256>, Vec<(Participant, Signature)>);
+/// Runs signing by calling the generic run_sign function from crate::test
+/// This signing mimics what should happen in real world, i.e.,
+/// rerandomizing the presignatures
+pub fn run_sign_with_rerandomization(
+    participants_presign: Vec<(Participant, PresignOutput)>,
+    public_key: Element,
+    msg: &[u8],
+) -> Result<SigWithRerand, Box<dyn Error>> {
+    // hash the message into secp256k1 field
+    let msg_hash = scalar_hash_secp256k1(msg);
+
+    // generate a random tweak
+    let tweak = Tweak::new(frost_core::random_nonzero::<Secp256K1Sha256, _>(&mut OsRng));
+    // generate a random public entropy
+    let mut entropy: [u8; 32] = [0u8; 32];
+    OsRng.fill_bytes(&mut entropy);
+
+    let pk = public_key.to_affine();
+    let big_r = participants_presign[0].1.big_r;
+    let participants = ParticipantList::new(
+        &participants_presign
+            .iter()
+            .map(|(p, _)| *p)
+            .collect::<Vec<Participant>>(),
+    )
+    .unwrap();
+    let rerand_args = RerandomizationArguments::new(&pk, &msg_hash, &big_r, &participants, entropy);
+    let public_key = frost_core::VerifyingKey::new(public_key);
+    let derived_pk = tweak.derive_verifying_key(&public_key).to_element();
+
+    let rerand_participants_presign = participants_presign
+        .iter()
+        .map(|(p, presig)| {
+            RerandomizedPresignOutput::new(presig, &tweak, &rerand_args).map(|out| (*p, out))
+        })
+        .collect::<Result<_, _>>()?;
+    // run sign instanciation with the necessary arguments
+    let vec = crate::test::run_sign::<Secp256K1Sha256, _, _, _>(
+        rerand_participants_presign,
+        derived_pk,
+        msg_hash,
+        |participants, me, pk, presignature, msg_hash| {
+            let pk = pk.to_affine();
+            sign(participants, me, pk, presignature, msg_hash)
+                .map(|sig| Box::new(sig) as Box<dyn Protocol<Output = Signature>>)
+        },
+    )?;
+    Ok((tweak, vec))
 }
 
 pub fn run_presign(
@@ -176,7 +233,6 @@ fn test_reshare_sign_less_participants() -> Result<(), Box<dyn Error>> {
     let (pub0, shares0) = deal(&mut OsRng, &new_participant, new_threshold)?;
     let (pub1, shares1) = deal(&mut OsRng, &new_participant, new_threshold)?;
 
-    // Presign
     let presign_result = run_presign(key_packages, shares0, shares1, &pub0, &pub1, new_threshold)?;
 
     let msg = b"hello world";

--- a/src/ecdsa/ot_based_ecdsa/test.rs
+++ b/src/ecdsa/ot_based_ecdsa/test.rs
@@ -4,6 +4,10 @@ use super::{
     triples::{test::deal, TriplePub, TripleShare},
     PresignArguments, PresignOutput,
 };
+use crate::ecdsa::{
+    Element, KeygenOutput, ParticipantList, RerandomizationArguments, Secp256K1Sha256, Signature,
+    Tweak,
+};
 use crate::protocol::{run_protocol, Participant, Protocol};
 use crate::test::{
     assert_public_key_invariant, generate_participants, generate_participants_with_random_ids,
@@ -12,17 +16,12 @@ use crate::test::{
 use crate::{
     crypto::hash::test::scalar_hash_secp256k1, ecdsa::ot_based_ecdsa::RerandomizedPresignOutput,
 };
-use crate::{
-    ecdsa::{
-        Element, KeygenOutput, ParticipantList, RerandomizationArguments, Secp256K1Sha256,
-        Signature,
-    },
-    Tweak,
-};
+
 use rand_core::{OsRng, RngCore};
 use std::error::Error;
 
 /// Runs signing by calling the generic run_sign function from crate::test
+/// This signing does not rerandomize the presignatures and tests only the core protocol
 pub fn run_sign_without_rerandomization(
     participants_presign: Vec<(Participant, PresignOutput)>,
     public_key: Element,
@@ -52,7 +51,7 @@ pub fn run_sign_without_rerandomization(
     )
 }
 
-type SigWithRerand = (Tweak<Secp256K1Sha256>, Vec<(Participant, Signature)>);
+type SigWithRerand = (Tweak, Vec<(Participant, Signature)>);
 /// Runs signing by calling the generic run_sign function from crate::test
 /// This signing mimics what should happen in real world, i.e.,
 /// rerandomizing the presignatures
@@ -283,7 +282,6 @@ fn test_e2e_random_identifiers() -> Result<(), Box<dyn Error>> {
     run_sign_without_rerandomization(presign_result, public_key.to_element(), msg)?;
     Ok(())
 }
-
 
 #[test]
 fn test_e2e_random_identifiers_with_rerandomization() -> Result<(), Box<dyn Error>> {

--- a/src/ecdsa/ot_based_ecdsa/test.rs
+++ b/src/ecdsa/ot_based_ecdsa/test.rs
@@ -283,3 +283,26 @@ fn test_e2e_random_identifiers() -> Result<(), Box<dyn Error>> {
     run_sign_without_rerandomization(presign_result, public_key.to_element(), msg)?;
     Ok(())
 }
+
+
+#[test]
+fn test_e2e_random_identifiers_with_rerandomization() -> Result<(), Box<dyn Error>> {
+    let participants_count = 3;
+    let participants = generate_participants_with_random_ids(participants_count);
+    let threshold = 3;
+
+    let key_packages = run_keygen(&participants.clone(), threshold)?;
+    assert_public_key_invariant(&key_packages);
+
+    let public_key = key_packages[0].1.public_key;
+
+    let (pub0, shares0) = deal(&mut OsRng, &participants, threshold)?;
+    let (pub1, shares1) = deal(&mut OsRng, &participants, threshold)?;
+
+    let presign_result = run_presign(key_packages, shares0, shares1, &pub0, &pub1, threshold)?;
+
+    let msg = b"hello world";
+    // internally verifies the signature's validity
+    run_sign_with_rerandomization(presign_result, public_key.to_element(), msg)?;
+    Ok(())
+}

--- a/src/ecdsa/robust_ecdsa/mod.rs
+++ b/src/ecdsa/robust_ecdsa/mod.rs
@@ -47,9 +47,9 @@ pub struct RerandomizedPresignOutput {
 
 impl RerandomizedPresignOutput {
     pub fn new(
-        presignature: PresignOutput,
-        tweak: Tweak,
-        args: RerandomizationArguments,
+        presignature: &PresignOutput,
+        tweak: &Tweak,
+        args: &RerandomizationArguments,
     ) -> Result<Self, ProtocolError> {
         if presignature.big_r != *args.big_r {
             return Err(ProtocolError::IncompatibleRerandomizationInputs);

--- a/src/ecdsa/robust_ecdsa/mod.rs
+++ b/src/ecdsa/robust_ecdsa/mod.rs
@@ -3,7 +3,10 @@ pub mod sign;
 #[cfg(test)]
 mod test;
 
-use crate::ecdsa::{AffinePoint, KeygenOutput, Scalar};
+use crate::{
+    ecdsa::{AffinePoint, KeygenOutput, Scalar},
+    // Tweak,
+};
 use serde::{Deserialize, Serialize};
 
 /// The necessary inputs for the creation of a presignature.
@@ -41,4 +44,6 @@ pub struct RerandomizedPresignOutput {
     beta_i: Scalar,
 }
 
-// Add deriving the public key
+// impl RerandomizedPresignOutput {
+//     pub fn new(presignature: PresignOutput, tweak: Tweak) -> Self {}
+// }

--- a/src/ecdsa/robust_ecdsa/mod.rs
+++ b/src/ecdsa/robust_ecdsa/mod.rs
@@ -3,10 +3,7 @@ pub mod sign;
 #[cfg(test)]
 mod test;
 
-use crate::{
-    ecdsa::{AffinePoint, KeygenOutput, Scalar},
-    // Tweak,
-};
+use crate::ecdsa::{AffinePoint, KeygenOutput, Scalar, Tweak};
 use serde::{Deserialize, Serialize};
 
 /// The necessary inputs for the creation of a presignature.
@@ -45,5 +42,7 @@ pub struct RerandomizedPresignOutput {
 }
 
 // impl RerandomizedPresignOutput {
-//     pub fn new(presignature: PresignOutput, tweak: Tweak) -> Self {}
+//     pub fn new(presignature: PresignOutput, tweak: Tweak, ) -> Self {
+
+//     }
 // }

--- a/src/ecdsa/robust_ecdsa/mod.rs
+++ b/src/ecdsa/robust_ecdsa/mod.rs
@@ -27,3 +27,18 @@ pub struct PresignOutput {
     pub alpha_i: Scalar,
     pub beta_i: Scalar,
 }
+
+/// The output of the presigning protocol.
+/// Contains the signature precomputed elements
+/// independently of the message
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RerandomizedPresignOutput {
+    /// The public nonce commitment.
+    big_r: AffinePoint,
+
+    /// Our secret shares of the nonces.
+    alpha_i: Scalar,
+    beta_i: Scalar,
+}
+
+// Add deriving the public key

--- a/src/ecdsa/robust_ecdsa/mod.rs
+++ b/src/ecdsa/robust_ecdsa/mod.rs
@@ -3,7 +3,10 @@ pub mod sign;
 #[cfg(test)]
 mod test;
 
-use crate::ecdsa::{AffinePoint, KeygenOutput, Scalar, Tweak};
+use crate::{
+    ecdsa::{AffinePoint, KeygenOutput, RerandomizationArguments, Scalar, Tweak},
+    protocol::errors::ProtocolError,
+};
 use serde::{Deserialize, Serialize};
 
 /// The necessary inputs for the creation of a presignature.
@@ -24,6 +27,7 @@ pub struct PresignOutput {
     pub big_r: AffinePoint,
 
     /// Our secret shares of the nonces.
+    pub k_i: Scalar,
     pub alpha_i: Scalar,
     pub beta_i: Scalar,
 }
@@ -33,16 +37,52 @@ pub struct PresignOutput {
 /// independently of the message
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RerandomizedPresignOutput {
-    /// The public nonce commitment.
+    /// The rerandomized public nonce commitment.
     big_r: AffinePoint,
 
-    /// Our secret shares of the nonces.
+    /// Our rerandomized secret shares of the nonces.
     alpha_i: Scalar,
     beta_i: Scalar,
 }
 
-// impl RerandomizedPresignOutput {
-//     pub fn new(presignature: PresignOutput, tweak: Tweak, ) -> Self {
+impl RerandomizedPresignOutput {
+    pub fn new(
+        presignature: PresignOutput,
+        tweak: Tweak,
+        args: RerandomizationArguments,
+    ) -> Result<Self, ProtocolError> {
+        if presignature.big_r != *args.big_r {
+            return Err(ProtocolError::IncompatibleRerandomizationInputs);
+        }
+        let delta = args.derive_randomness();
+        let rerandomized_big_r = presignature.big_r * delta;
+        let inv_delta = delta.invert();
+        if inv_delta.is_none().into() {
+            return Err(ProtocolError::AssertionFailed(
+                "expected a non-zero randomness".to_string(),
+            ));
+        }
 
-//     }
-// }
+        // cannot fail due to the previous check
+        let inv_delta = inv_delta.unwrap();
+
+        let rerandomized_alpha_i =
+            (presignature.alpha_i + tweak.value() * presignature.k_i) * inv_delta;
+        Ok(RerandomizedPresignOutput {
+            big_r: rerandomized_big_r.into(),
+            alpha_i: rerandomized_alpha_i,
+            beta_i: presignature.beta_i,
+        })
+    }
+
+    #[cfg(test)]
+    /// Outputs the same elements as in the PresignatureOutput
+    /// Used for testing the core schemes without rerandomization
+    pub fn new_without_rerandomization(presignature: PresignOutput) -> Self {
+        RerandomizedPresignOutput {
+            big_r: presignature.big_r,
+            alpha_i: presignature.alpha_i,
+            beta_i: presignature.beta_i,
+        }
+    }
+}

--- a/src/ecdsa/robust_ecdsa/presign.rs
+++ b/src/ecdsa/robust_ecdsa/presign.rs
@@ -5,7 +5,7 @@ use rand_core::OsRng;
 use super::{PresignArguments, PresignOutput};
 use crate::{
     ecdsa::{
-        x_coordinate, CoefficientCommitment, Field, Polynomial, PolynomialCommitment, Scalar,
+        CoefficientCommitment, Field, Polynomial, PolynomialCommitment, Scalar,
         Secp256K1ScalarField, Secp256K1Sha256,
     },
     participants::{ParticipantCounter, ParticipantList, ParticipantMap},
@@ -268,20 +268,20 @@ async fn do_presign(
     }
 
     // w is non-zero due to previous check and so I can unwrap safely
-    let h_me = w.0.invert().unwrap() * shares.a();
+    let c_me = w.0.invert().unwrap() * shares.a();
 
     // Some extra computation is pushed in this offline phase
-    let alpha_me = h_me + shares.d();
+    let alpha_me = c_me + shares.d();
 
-    let big_r_x_coordinate = x_coordinate(&big_r.value().to_affine());
     let x_me = args.keygen_out.private_share.to_scalar();
-    let beta_me = h_me * big_r_x_coordinate * x_me + shares.e();
+    let beta_me = c_me * x_me;
 
     Ok(PresignOutput {
         big_r: big_r.value().to_affine(),
         alpha: alpha_me,
         beta: beta_me,
-        k: shares.k(),
+        c: c_me,
+        e: shares.e(),
     })
 }
 

--- a/src/ecdsa/robust_ecdsa/presign.rs
+++ b/src/ecdsa/robust_ecdsa/presign.rs
@@ -279,9 +279,9 @@ async fn do_presign(
 
     Ok(PresignOutput {
         big_r: big_r.value().to_affine(),
-        alpha_i: alpha_me,
-        beta_i: beta_me,
-        k_i: shares.k(),
+        alpha: alpha_me,
+        beta: beta_me,
+        k: shares.k(),
     })
 }
 

--- a/src/ecdsa/robust_ecdsa/presign.rs
+++ b/src/ecdsa/robust_ecdsa/presign.rs
@@ -281,6 +281,7 @@ async fn do_presign(
         big_r: big_r.value().to_affine(),
         alpha_i: alpha_me,
         beta_i: beta_me,
+        k_i: shares.k(),
     })
 }
 

--- a/src/ecdsa/robust_ecdsa/sign.rs
+++ b/src/ecdsa/robust_ecdsa/sign.rs
@@ -122,23 +122,25 @@ mod test {
 
     use super::*;
     use crate::ecdsa::{
-        robust_ecdsa::test::run_sign_without_rerandomization, robust_ecdsa::PresignOutput,
+        robust_ecdsa::test::{run_sign_with_rerandomization, run_sign_without_rerandomization},
+        robust_ecdsa::PresignOutput,
         x_coordinate, Field, ProjectivePoint, Secp256K1ScalarField,
     };
     use crate::test::generate_participants;
 
-    #[test]
-    fn test_sign_given_presignature() -> Result<(), Box<dyn Error>> {
-        let max_malicious = 2;
-        let msg = b"Hello? Is it me you're looking for?";
+    type PresigSimulationOutput = (
+        Scalar,
+        Polynomial,
+        Polynomial,
+        Polynomial,
+        Polynomial,
+        ProjectivePoint,
+        Scalar,
+    );
 
-        // Manually compute presignatures then deliver them to the signing function
-        let fx = Polynomial::generate_polynomial(None, max_malicious, &mut OsRng)?;
-        // master secret key
-        let x = fx.eval_at_zero()?.0;
-        // master public key
-        let public_key = ProjectivePoint::GENERATOR * x;
-
+    fn simulate_presignature(
+        max_malicious: usize,
+    ) -> Result<PresigSimulationOutput, Box<dyn Error>> {
         // the presignatures scheme requires the generation of 5 different polynomials
         // (fk, fa, fb, fd, fe)
         // here we do not need fb as it is only used to mask some values before sending
@@ -166,6 +168,23 @@ mod test {
         let w = fa.eval_at_zero()?.0 * k;
         let w_invert = w.invert().unwrap();
 
+        Ok((w_invert, fa, fd, fe, fk, big_r, big_r_x_coordinate))
+    }
+
+    #[test]
+    fn test_sign_given_presignature() -> Result<(), Box<dyn Error>> {
+        let max_malicious = 2;
+        let msg = b"Hello? Is it me you're looking for?";
+
+        // Manually compute presignatures then deliver them to the signing function
+        let fx = Polynomial::generate_polynomial(None, max_malicious, &mut OsRng)?;
+        // master secret key
+        let x = fx.eval_at_zero()?.0;
+        // master public key
+        let public_key = ProjectivePoint::GENERATOR * x;
+
+        let (w_invert, fa, fd, fe, fk, big_r, big_r_x_coordinate) =
+            simulate_presignature(max_malicious)?;
         let participants = generate_participants(5);
 
         let mut participants_presign = Vec::new();
@@ -189,6 +208,53 @@ mod test {
         let result = run_sign_without_rerandomization(participants_presign, public_key, msg)?;
         let sig = result[0].1.clone();
         let sig = ecdsa::Signature::from_scalars(x_coordinate(&sig.big_r), sig.s)?;
+
+        // verify the correctness of the generated signature
+        VerifyingKey::from(&PublicKey::from_affine(public_key.to_affine()).unwrap())
+            .verify(&msg[..], &sig)?;
+        Ok(())
+    }
+
+    #[test]
+    fn test_sign_given_presignature_with_rerandomization() -> Result<(), Box<dyn Error>> {
+        let max_malicious = 2;
+        let msg = b"Hello? Is it me you're looking for?";
+
+        // Manually compute presignatures then deliver them to the signing function
+        let fx = Polynomial::generate_polynomial(None, max_malicious, &mut OsRng)?;
+        // master secret key
+        let x = fx.eval_at_zero()?.0;
+        // master public key
+        let public_key = frost_core::VerifyingKey::new(ProjectivePoint::GENERATOR * x);
+
+        let (w_invert, fa, fd, fe, fk, big_r, big_r_x_coordinate) =
+            simulate_presignature(max_malicious)?;
+        let participants = generate_participants(5);
+
+        let mut participants_presign = Vec::new();
+        // Simulate the each participant's presignature
+        for p in &participants {
+            let h_i = w_invert * fa.eval_at_participant(*p)?.0;
+            let alpha = h_i + fd.eval_at_participant(*p)?.0;
+            let beta = h_i * big_r_x_coordinate * fx.eval_at_participant(*p)?.0
+                + fe.eval_at_participant(*p)?.0;
+            let k = fk.eval_at_participant(*p)?.0;
+            // build the presignature
+            let presignature = PresignOutput {
+                big_r: big_r.to_affine(),
+                alpha,
+                beta,
+                k,
+            };
+            participants_presign.push((*p, presignature));
+        }
+
+        let (tweak, result) =
+            run_sign_with_rerandomization(participants_presign, public_key.to_element(), msg)?;
+        let sig = result[0].1.clone();
+        let sig = ecdsa::Signature::from_scalars(x_coordinate(&sig.big_r), sig.s)?;
+        // derive the public key
+        let public_key = tweak.derive_verifying_key(&public_key).to_element();
 
         // verify the correctness of the generated signature
         VerifyingKey::from(&PublicKey::from_affine(public_key.to_affine()).unwrap())

--- a/src/ecdsa/robust_ecdsa/sign.rs
+++ b/src/ecdsa/robust_ecdsa/sign.rs
@@ -61,7 +61,7 @@ async fn do_sign(
     presignature: RerandomizedPresignOutput,
     msg_hash: Scalar,
 ) -> Result<Signature, ProtocolError> {
-    let s_me = msg_hash * presignature.alpha_i + presignature.beta_i;
+    let s_me = msg_hash * presignature.alpha + presignature.beta;
     let s_me = SerializableScalar(s_me);
 
     let wait_round = chan.next_waitpoint();
@@ -172,16 +172,16 @@ mod test {
         // Simulate the each participant's presignature
         for p in &participants {
             let h_i = w_invert * fa.eval_at_participant(*p)?.0;
-            let alpha_i = h_i + fd.eval_at_participant(*p)?.0;
-            let beta_i = h_i * big_r_x_coordinate * fx.eval_at_participant(*p)?.0
+            let alpha = h_i + fd.eval_at_participant(*p)?.0;
+            let beta = h_i * big_r_x_coordinate * fx.eval_at_participant(*p)?.0
                 + fe.eval_at_participant(*p)?.0;
-            let k_i = fk.eval_at_participant(*p)?.0;
+            let k = fk.eval_at_participant(*p)?.0;
             // build the presignature
             let presignature = PresignOutput {
                 big_r: big_r.to_affine(),
-                alpha_i,
-                beta_i,
-                k_i,
+                alpha,
+                beta,
+                k,
             };
             participants_presign.push((*p, presignature));
         }

--- a/src/ecdsa/robust_ecdsa/test.rs
+++ b/src/ecdsa/robust_ecdsa/test.rs
@@ -243,3 +243,21 @@ fn test_e2e_random_identifiers() -> Result<(), Box<dyn Error>> {
     run_sign_without_rerandomization(presign_result, public_key.to_element(), msg)?;
     Ok(())
 }
+
+#[test]
+fn test_e2e_random_identifiers_with_rerandomization() -> Result<(), Box<dyn Error>> {
+    let participants_count = 7;
+    let participants = generate_participants_with_random_ids(participants_count);
+    let max_malicious = 3;
+
+    let keygen_result = run_keygen(&participants.clone(), max_malicious + 1)?;
+    assert_public_key_invariant(&keygen_result);
+
+    let public_key = keygen_result[0].1.public_key;
+    assert_public_key_invariant(&keygen_result);
+    let presign_result = run_presign(keygen_result, max_malicious)?;
+
+    let msg = b"hello world";
+    run_sign_with_rerandomization(presign_result, public_key.to_element(), msg)?;
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,22 +1,30 @@
 mod crypto;
-// For benchmark
-pub use crypto::polynomials::{
-    batch_compute_lagrange_coefficients, batch_invert, compute_lagrange_coefficient,
-};
 mod generic_dkg;
 mod participants;
-
-pub mod protocol;
 
 pub mod confidential_key_derivation;
 pub mod ecdsa;
 pub mod eddsa;
+pub mod protocol;
+#[cfg(test)]
+mod test;
 
 pub use frost_core;
 pub use frost_ed25519;
 pub use frost_secp256k1;
-#[cfg(test)]
-mod test;
+// For benchmark
+pub use crypto::polynomials::{
+    batch_compute_lagrange_coefficients, batch_invert, compute_lagrange_coefficient,
+};
+
+use crypto::ciphersuite::Ciphersuite;
+use frost_core::{keys::SigningShare, Group, VerifyingKey};
+use serde::{Deserialize, Serialize};
+use std::marker::Send;
+
+use crate::generic_dkg::*;
+use crate::protocol::internal::{make_protocol, Comms};
+use crate::protocol::{errors::InitializationError, Participant, Protocol};
 
 type Scalar<C> = frost_core::Scalar<C>;
 
@@ -43,13 +51,13 @@ impl<C: Ciphersuite> Tweak<C> {
         self.0
     }
 
-    /// Derives the signing share
+    /// Derives the signing share as x + tweak
     pub fn derive_signing_share(&self, private_share: &SigningShare<C>) -> SigningShare<C> {
         let derived_share = private_share.to_scalar() + self.value();
         SigningShare::new(derived_share)
     }
 
-    /// Derives the verifying key
+    /// Derives the verifying key as X + tweak . G
     pub fn derive_verifying_key(&self, public_key: &VerifyingKey<C>) -> VerifyingKey<C> {
         let derived_share = public_key.to_element() + C::Group::generator() * self.value();
         VerifyingKey::new(derived_share)
@@ -146,13 +154,3 @@ where
     );
     Ok(make_protocol(comms, fut))
 }
-
-// Libraries calls
-use crypto::ciphersuite::Ciphersuite;
-use frost_core::{keys::SigningShare, Group, VerifyingKey};
-use serde::{Deserialize, Serialize};
-use std::marker::Send;
-
-use crate::generic_dkg::*;
-use crate::protocol::internal::{make_protocol, Comms};
-use crate::protocol::{errors::InitializationError, Participant, Protocol};

--- a/src/protocol/errors.rs
+++ b/src/protocol/errors.rs
@@ -25,6 +25,9 @@ pub enum ProtocolError {
     #[error("encountered the identity element (identity point)")]
     IdentityElement,
 
+    #[error("cannot rerandomize presignature with incompatible inputs")]
+    IncompatibleRerandomizationInputs,
+
     #[error("the sent commitment_hash does not equal the hash of the commitment")]
     InvalidCommitmentHash,
 


### PR DESCRIPTION
Adding rerandomization and key derivation of the presignature API is added to this repo.

The original robust ecdsa scheme had to be modified to allow rerandomization of the presignature.
The documentation #76  is being updated accordingly.

This is tightly related to #59.

This requires modifying (relaxing) the framework of MPC repo