### PR TITLE
Adding coordinator and Participants to Robust ECDSA scheme

### DIFF
--- a/src/confidential_key_derivation/protocol.rs
+++ b/src/confidential_key_derivation/protocol.rs
@@ -182,9 +182,9 @@ mod test {
     use super::*;
     use crate::crypto::polynomials::Polynomial;
     use crate::protocol::run_protocol;
-    use std::error::Error;
-
+    use crate::test::one_coordinator_output;
     use rand_core::RngCore;
+    use std::error::Error;
 
     #[test]
     fn test_hash2curve() -> Result<(), Box<dyn Error>> {
@@ -249,16 +249,7 @@ mod test {
         let result = run_protocol(protocols)?;
 
         // test one single some for the coordinator
-        let mut some_iter = result.into_iter().filter(|(_, ckd)| ckd.is_some());
-
-        let ckd = some_iter
-            .next()
-            .map(|(_, c)| c.unwrap())
-            .expect("Expected exactly one Some(CKDCoordinatorOutput)");
-        assert!(
-            some_iter.next().is_none(),
-            "More than one Some(CKDCoordinatorOutput)"
-        );
+        let ckd = one_coordinator_output(result, coordinator)?;
 
         // compute msk . H(app_id)
         let confidential_key = ckd.unmask(app_sk);

--- a/src/ecdsa/mod.rs
+++ b/src/ecdsa/mod.rs
@@ -72,6 +72,9 @@ impl Signature {
     }
 }
 
+/// None for participants and Some for coordinator
+pub type SignatureOption = Option<Signature>;
+
 /// The arguments used to derive randomness used for presignature rerandomization.
 /// Presignature rerandomization has been thoroughly described in
 /// [GS21] https://eprint.iacr.org/2021/1330.pdf

--- a/src/ecdsa/robust_ecdsa/test.rs
+++ b/src/ecdsa/robust_ecdsa/test.rs
@@ -6,12 +6,12 @@ use crate::crypto::hash::test::scalar_hash_secp256k1;
 use crate::ecdsa::robust_ecdsa::RerandomizedPresignOutput;
 use crate::ecdsa::{
     Element, KeygenOutput, ParticipantList, RerandomizationArguments, Secp256K1Sha256, Signature,
-    Tweak,
+    SignatureOption, Tweak,
 };
 use crate::protocol::{run_protocol, Participant, Protocol};
 use crate::test::{
     assert_public_key_invariant, generate_participants, generate_participants_with_random_ids,
-    run_keygen, run_refresh, run_reshare,
+    one_coordinator_output, run_keygen, run_refresh, run_reshare,
 };
 
 use rand_core::{OsRng, RngCore};
@@ -22,25 +22,35 @@ pub fn run_sign_without_rerandomization(
     participants_presign: Vec<(Participant, PresignOutput)>,
     public_key: Element,
     msg: &[u8],
-) -> Result<Vec<(Participant, Signature)>, Box<dyn Error>> {
+) -> Result<(Participant, Signature), Box<dyn Error>> {
     // hash the message into secp256k1 field
     let msg_hash = scalar_hash_secp256k1(msg);
+
+    // choose a coordinator at random
+    let index = OsRng.next_u32() % participants_presign.len() as u32;
+    let coordinator = participants_presign[index as usize].0;
+
     // run sign instanciation with the necessary arguments
-    crate::test::run_sign::<Secp256K1Sha256, _, _, _>(
+    let result = crate::test::run_asymmetric_sign::<Secp256K1Sha256, _, _, _>(
         participants_presign,
+        coordinator,
         public_key,
         msg_hash,
-        |participants, me, pk, presignature, msg_hash| {
+        |participants, coordinator, me, pk, presignature, msg_hash| {
             let pk = pk.to_affine();
             let rerand_presig =
                 RerandomizedPresignOutput::new_without_rerandomization(presignature);
-            sign(participants, me, pk, rerand_presig, msg_hash)
-                .map(|sig| Box::new(sig) as Box<dyn Protocol<Output = Signature>>)
+            sign(participants, coordinator, me, pk, rerand_presig, msg_hash)
+                .map(|sig| Box::new(sig) as Box<dyn Protocol<Output = SignatureOption>>)
         },
-    )
+    )?;
+    // test one single some for the coordinator
+    let signature = one_coordinator_output(result, coordinator)?;
+
+    Ok((coordinator, signature))
 }
 
-type SigWithRerand = (Tweak, Vec<(Participant, Signature)>);
+type SigWithRerand = (Tweak, Participant, Signature);
 /// Runs signing by calling the generic run_sign function from crate::test
 /// This signing mimics what should happen in real world, i.e.,
 /// rerandomizing the presignatures
@@ -77,18 +87,26 @@ pub fn run_sign_with_rerandomization(
             RerandomizedPresignOutput::new(presig, &tweak, &rerand_args).map(|out| (*p, out))
         })
         .collect::<Result<_, _>>()?;
+
+    // choose a coordinator at random
+    let index = OsRng.next_u32() % participants_presign.len() as u32;
+    let coordinator = participants_presign[index as usize].0;
+
     // run sign instanciation with the necessary arguments
-    let vec = crate::test::run_sign::<Secp256K1Sha256, _, _, _>(
+    let result = crate::test::run_asymmetric_sign::<Secp256K1Sha256, _, _, _>(
         rerand_participants_presign,
+        coordinator,
         derived_pk,
         msg_hash,
-        |participants, me, pk, presignature, msg_hash| {
+        |participants, coordinator, me, pk, presignature, msg_hash| {
             let pk = pk.to_affine();
-            sign(participants, me, pk, presignature, msg_hash)
-                .map(|sig| Box::new(sig) as Box<dyn Protocol<Output = Signature>>)
+            sign(participants, coordinator, me, pk, presignature, msg_hash)
+                .map(|sig| Box::new(sig) as Box<dyn Protocol<Output = SignatureOption>>)
         },
     )?;
-    Ok((tweak, vec))
+    // test one single some for the coordinator
+    let signature = one_coordinator_output(result, coordinator)?;
+    Ok((tweak, coordinator, signature))
 }
 
 pub fn run_presign(

--- a/src/eddsa/mod.rs
+++ b/src/eddsa/mod.rs
@@ -18,4 +18,4 @@ impl ScalarSerializationFormat for Ed25519Sha512 {
 impl Ciphersuite for Ed25519Sha512 {}
 
 /// Signature would be Some for coordinator and None for other participants
-pub type Signature = Option<frost_ed25519::Signature>;
+pub type SignatureOption = Option<frost_ed25519::Signature>;

--- a/src/eddsa/sign.rs
+++ b/src/eddsa/sign.rs
@@ -1,6 +1,6 @@
 //! This module wraps a signature generation functionality from `Frost` library
 //!  into `cait-sith::Protocol` representation.
-use super::{KeygenOutput, Signature};
+use super::{KeygenOutput, SignatureOption};
 use crate::participants::{ParticipantCounter, ParticipantList};
 use crate::protocol::errors::{InitializationError, ProtocolError};
 use crate::protocol::internal::{make_protocol, Comms, SharedChannel};
@@ -48,7 +48,7 @@ async fn do_sign_coordinator(
     me: Participant,
     keygen_output: KeygenOutput,
     message: Vec<u8>,
-) -> Result<Signature, ProtocolError> {
+) -> Result<SignatureOption, ProtocolError> {
     let mut seen = ParticipantCounter::new(&participants);
     let mut rng = OsRng;
 
@@ -137,7 +137,7 @@ async fn do_sign_participant(
     coordinator: Participant,
     keygen_output: KeygenOutput,
     message: Vec<u8>,
-) -> Result<Signature, ProtocolError> {
+) -> Result<SignatureOption, ProtocolError> {
     let mut rng = OsRng;
     if coordinator == me {
         return Err(ProtocolError::AssertionFailed(
@@ -208,7 +208,7 @@ pub fn sign(
     coordinator: Participant,
     keygen_output: KeygenOutput,
     message: Vec<u8>,
-) -> Result<impl Protocol<Output = Signature>, InitializationError> {
+) -> Result<impl Protocol<Output = SignatureOption>, InitializationError> {
     if participants.len() < 2 {
         return Err(InitializationError::NotEnoughParticipants {
             participants: participants.len(),
@@ -254,7 +254,7 @@ async fn fut_wrapper(
     coordinator: Participant,
     keygen_output: KeygenOutput,
     message: Vec<u8>,
-) -> Result<Signature, ProtocolError> {
+) -> Result<SignatureOption, ProtocolError> {
     if me == coordinator {
         do_sign_coordinator(chan, participants, threshold, me, keygen_output, message).await
     } else {
@@ -276,7 +276,7 @@ mod test {
     use std::error::Error;
 
     fn assert_single_coordinator_result(
-        data: Vec<(Participant, super::Signature)>,
+        data: Vec<(Participant, super::SignatureOption)>,
     ) -> frost_ed25519::Signature {
         let mut signature = None;
         let count = data

--- a/src/eddsa/test.rs
+++ b/src/eddsa/test.rs
@@ -1,5 +1,5 @@
 use crate::crypto::hash::HashOutput;
-use crate::eddsa::{sign::sign, KeygenOutput, Signature};
+use crate::eddsa::{sign::sign, KeygenOutput, SignatureOption};
 use crate::participants::ParticipantList;
 use crate::protocol::{run_protocol, Participant, Protocol};
 use crate::test::MockCryptoRng;
@@ -62,8 +62,8 @@ pub(crate) fn test_run_signature_protocols(
     coordinators: &[Participant],
     threshold: usize,
     msg_hash: HashOutput,
-) -> Result<Vec<(Participant, Signature)>, Box<dyn Error>> {
-    let mut protocols: Vec<(Participant, Box<dyn Protocol<Output = Signature>>)> =
+) -> Result<Vec<(Participant, SignatureOption)>, Box<dyn Error>> {
+    let mut protocols: Vec<(Participant, Box<dyn Protocol<Output = SignatureOption>>)> =
         Vec::with_capacity(participants.len());
 
     let participants_list = participants

--- a/src/protocol/errors.rs
+++ b/src/protocol/errors.rs
@@ -52,6 +52,9 @@ pub enum ProtocolError {
     #[error("the constructed signing key is null")]
     MalformedSigningKey,
 
+    #[error("Expected exactly one output that belongs only to the coordinator")]
+    MismatchCoordinatorOutput,
+
     #[error("the group element could not be serialized")]
     PointSerialization,
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -4,7 +4,10 @@
 use rand_core::{CryptoRng, OsRng, RngCore};
 use std::error::Error;
 
-use crate::protocol::{errors::InitializationError, run_protocol, Participant, Protocol};
+use crate::protocol::{
+    errors::{InitializationError, ProtocolError},
+    run_protocol, Participant, Protocol,
+};
 use crate::{keygen, refresh, reshare, Ciphersuite, KeygenOutput, VerifyingKey};
 
 // +++++++++++++++++ Participants Utilities +++++++++++++++++ //
@@ -176,6 +179,74 @@ where
     }
 
     Ok(run_protocol(protocols)?)
+}
+
+/// Runs the signing algorithm for ECDSA.
+/// The scheme must be asymmetric as in: there exists a coordinator that is different than participants.
+/// Only used for unit tests.
+pub(crate) fn run_asymmetric_sign<C: Ciphersuite, PresignOutput, Signature: Clone, F>(
+    participants_presign: Vec<(Participant, PresignOutput)>,
+    coordinator: Participant,
+    public_key: frost_core::Element<C>,
+    msg_hash: frost_core::Scalar<C>,
+    sign: F,
+) -> Result<Vec<(Participant, Signature)>, Box<dyn Error>>
+where
+    F: Fn(
+        &[Participant],
+        Participant,
+        Participant,
+        frost_core::Element<C>,
+        PresignOutput,
+        frost_core::Scalar<C>,
+    ) -> Result<Box<dyn Protocol<Output = Signature>>, InitializationError>,
+{
+    let mut protocols: Vec<(Participant, Box<dyn Protocol<Output = Signature>>)> =
+        Vec::with_capacity(participants_presign.len());
+
+    let participants: Vec<Participant> = participants_presign.iter().map(|(p, _)| *p).collect();
+    let participants = participants.as_slice();
+    for (p, presignature) in participants_presign.into_iter() {
+        let protocol = sign(
+            participants,
+            coordinator,
+            p,
+            public_key,
+            presignature,
+            msg_hash,
+        )?;
+
+        protocols.push((p, protocol));
+    }
+
+    Ok(run_protocol(protocols)?)
+}
+
+/// Checks that the list contains all None but one element
+/// and verifies such element belongs to the coordinator
+pub(crate) fn one_coordinator_output<ProtocolOutput: Clone>(
+    all_sigs: Vec<(Participant, Option<ProtocolOutput>)>,
+    coordinator: Participant,
+) -> Result<ProtocolOutput, ProtocolError> {
+    let mut some_iter = all_sigs.into_iter().filter(|(_, sig)| sig.is_some());
+
+    // test there is at least one not None element
+    let (p, c_opt) = some_iter
+        .next()
+        .ok_or(ProtocolError::MismatchCoordinatorOutput)?;
+
+    // test the coordinator is the one owning the output
+    if coordinator != p {
+        return Err(ProtocolError::MismatchCoordinatorOutput);
+    }
+
+    // test the participant is unique
+    let out = c_opt.ok_or(ProtocolError::MismatchCoordinatorOutput)?;
+
+    if some_iter.next().is_some() {
+        return Err(ProtocolError::MismatchCoordinatorOutput);
+    };
+    Ok(out)
 }
 
 // Taken from https://rust-random.github.io/book/guide-test-fn-rng.html


### PR DESCRIPTION
This PR aims to introduce asymmetry in the signing by having a coordinator and participants for the robust ECDSA scheme.

We added in the tests.rs files a generic function for this functionality.
Due to now the existence of two testing functions that runs the signing protocol, we would be happy to have an upcoming PR that transform the online phase of the OT-based ECDSA Scheme.