### PR TITLE
Simon/no panic participants index

### DIFF
--- a/src/ecdsa/ot_based_ecdsa/triples/generation.rs
+++ b/src/ecdsa/ot_based_ecdsa/triples/generation.rs
@@ -243,7 +243,7 @@ async fn do_generation(
                 )));
             }
 
-            if !all_commitments[from]
+            if !all_commitments.index(from)?
                 .check(
                     &(&their_big_e, &their_big_f, &their_big_l),
                     &their_randomizer,
@@ -346,7 +346,7 @@ async fn do_generation(
             let big_c_j = big_c_j.value();
 
             let statement = dlogeq::Statement::<C> {
-                public0: &big_e_j_zero[from].value(),
+                public0: &big_e_j_zero.index(from)?.value(),
                 generator1: &big_f.eval_at_zero()?.value(),
                 public1: &big_c_j,
             };
@@ -773,7 +773,7 @@ async fn do_generation_many<const N: usize>(
                     )));
                 }
 
-                if !all_commitments[from]
+                if !all_commitments.index(from)?
                     .check(
                         &(&their_big_e, &their_big_f, &their_big_l),
                         their_randomizer,
@@ -906,7 +906,7 @@ async fn do_generation_many<const N: usize>(
                 let their_phi_proof = &their_phi_proofs[i];
 
                 let statement = dlogeq::Statement::<C> {
-                    public0: &big_e_j_zero[from].value(),
+                    public0: &big_e_j_zero.index(from)?.value(),
                     generator1: &big_f.eval_at_zero()?.value(),
                     public1: &big_c_j,
                 };

--- a/src/ecdsa/ot_based_ecdsa/triples/generation.rs
+++ b/src/ecdsa/ot_based_ecdsa/triples/generation.rs
@@ -243,7 +243,8 @@ async fn do_generation(
                 )));
             }
 
-            if !all_commitments.index(from)?
+            if !all_commitments
+                .index(from)?
                 .check(
                     &(&their_big_e, &their_big_f, &their_big_l),
                     &their_randomizer,
@@ -773,7 +774,8 @@ async fn do_generation_many<const N: usize>(
                     )));
                 }
 
-                if !all_commitments.index(from)?
+                if !all_commitments
+                    .index(from)?
                     .check(
                         &(&their_big_e, &their_big_f, &their_big_l),
                         their_randomizer,

--- a/src/generic_dkg.rs
+++ b/src/generic_dkg.rs
@@ -20,7 +20,6 @@ use frost_core::{
     Challenge, Element, Error, Field, Group, Scalar, Signature, SigningKey, VerifyingKey,
 };
 use rand_core::CryptoRngCore;
-use std::ops::Index;
 
 /// This function prevents calling keyshare function with inproper inputs
 fn assert_keyshare_inputs<C: Ciphersuite>(
@@ -218,7 +217,7 @@ fn verify_commitment_hash<C: Ciphersuite>(
     commitment: &VerifiableSecretSharingCommitment<C>,
     all_hash_commitments: &ParticipantMap<'_, HashOutput>,
 ) -> Result<(), ProtocolError> {
-    let actual_commitment_hash = all_hash_commitments.index(participant);
+    let actual_commitment_hash = all_hash_commitments.index(participant)?;
     let commitment_hash =
         domain_separate_hash(domain_separator, &(&participant, &commitment, &session_id))?;
     if *actual_commitment_hash != commitment_hash {
@@ -417,7 +416,7 @@ async fn do_keyshare<C: Ciphersuite>(
     // Start Round 3
     let wait_round_3 = chan.next_waitpoint();
     for p in participants.others(me) {
-        let (commitment_i, proof_i) = commitments_and_proofs_map.index(p);
+        let (commitment_i, proof_i) = commitments_and_proofs_map.index(p)?;
 
         // verify the proof of knowledge
         // if proof is none then make sure the participant is new
@@ -490,7 +489,7 @@ async fn do_keyshare<C: Ciphersuite>(
         // Verify the share
         // this deviates from the original FROST DKG paper
         // however it matches the FROST implementation of ZCash
-        let full_commitment_from = all_full_commitments.index(from);
+        let full_commitment_from = all_full_commitments.index(from)?;
         validate_received_share::<C>(&me, &from, &signing_share_from, full_commitment_from)?;
 
         // Compute the sum of all the owned secret shares

--- a/src/participants.rs
+++ b/src/participants.rs
@@ -280,3 +280,27 @@ impl<'a> ParticipantCounter<'a> {
         self.counter == 0
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::test::generate_participants;
+
+    #[test]
+    fn test_get_index_participant_error() {
+        let participants = generate_participants(5);
+        let participants = ParticipantList::new(&participants).unwrap();
+        assert!(participants.index(&Participant::from(1234_u32)).is_err())
+    }
+
+    #[test]
+    fn test_get_index_data_error() {
+        let participants = generate_participants(5);
+        let participants = ParticipantList::new(&participants).unwrap();
+        let map: ParticipantMap<'_, u32> = ParticipantMap::new(&participants);
+        // no participant test
+        assert!(map.index(Participant::from(1233_u32)).is_err());
+        // no data test
+        assert!(map.index(Participant::from(1_u32)).is_err())
+    }
+}

--- a/src/participants.rs
+++ b/src/participants.rs
@@ -73,9 +73,9 @@ impl ParticipantList {
         self.indices
             .get(participant)
             .copied()
-            .ok_or(
-                ProtocolError::Other("Could not find the searched participant".to_string())
-            )
+            .ok_or(ProtocolError::Other(
+                "Could not find the searched participant".to_string(),
+            ))
     }
 
     // Return a participant of a given index from the order they
@@ -213,13 +213,11 @@ impl<'a, T> ParticipantMap<'a, T> {
         let index = self.participants.index(&index)?;
         self.data
             .get(index)
-            .ok_or(
-                ProtocolError::Other("Data index not found in map".to_string())
-            )?
+            .ok_or(ProtocolError::Other(
+                "Data index not found in map".to_string(),
+            ))?
             .as_ref()
-            .ok_or(
-                ProtocolError::Other("No data found".to_string())
-            )
+            .ok_or(ProtocolError::Other("No data found".to_string()))
     }
 }
 

--- a/src/protocol/echo_broadcast.rs
+++ b/src/protocol/echo_broadcast.rs
@@ -338,7 +338,6 @@ mod test {
         Ok(vote_list)
     }
 
-    #[allow(clippy::type_complexity)]
     pub fn do_broadcast_honest(
         participants: &[Participant],
         me: Participant,
@@ -359,14 +358,13 @@ mod test {
     }
 
     /// All participants are assumed to be honest here
-    #[allow(clippy::type_complexity)]
     fn broadcast_honest(
         participants: &[Participant],
         votes: &[bool],
-    ) -> Result<Vec<(Participant, Vec<bool>)>, Box<dyn Error>> {
+    ) -> Result<Vec<(Participant, Vec<bool>)>, ProtocolError> {
         assert_eq!(participants.len(), votes.len());
 
-        let mut protocols: Vec<(Participant, Box<dyn Protocol<Output = Vec<bool>>>)> =
+        let mut protocols: Vec<(_, Box<dyn Protocol<Output = Vec<bool>>>)> =
             Vec::with_capacity(participants.len());
 
         for (p, b) in participants.iter().zip(votes.iter()) {
@@ -432,7 +430,6 @@ mod test {
         Ok(vote_list)
     }
 
-    #[allow(clippy::type_complexity)]
     pub fn do_broadcast_dishonest_v1(
         participants: &[Participant],
         me: Participant,
@@ -453,7 +450,6 @@ mod test {
         Ok(make_protocol(comms, fut))
     }
 
-    #[allow(clippy::type_complexity)]
     pub fn do_broadcast_dishonest_v2(
         participants: &[Participant],
         me: Participant,
@@ -474,18 +470,17 @@ mod test {
         Ok(make_protocol(comms, fut))
     }
 
-    #[allow(clippy::type_complexity)]
     fn broadcast_dishonest_v1(
         honest_participants: &[Participant],
         dishonest_participant: &Participant,
         honest_votes: &[bool],
-    ) -> Result<Vec<(Participant, Vec<bool>)>, Box<dyn Error>> {
+    ) -> Result<Vec<(Participant, Vec<bool>)>, ProtocolError> {
         assert_eq!(honest_participants.len(), honest_votes.len());
 
         let mut participants = honest_participants.to_vec();
         participants.push(*dishonest_participant);
 
-        let mut protocols: Vec<(Participant, Box<dyn Protocol<Output = Vec<bool>>>)> =
+        let mut protocols: Vec<(_, Box<dyn Protocol<Output = Vec<bool>>>)> =
             Vec::with_capacity(participants.len());
 
         // we run the protocol for all honest parties
@@ -503,18 +498,17 @@ mod test {
         Ok(result)
     }
 
-    #[allow(clippy::type_complexity)]
     fn broadcast_dishonest_v2(
         honest_participants: &[Participant],
         dishonest_participant: &Participant,
         honest_votes: &[bool],
-    ) -> Result<Vec<(Participant, Vec<bool>)>, Box<dyn Error>> {
+    ) -> Result<Vec<(Participant, Vec<bool>)>, ProtocolError> {
         assert_eq!(honest_participants.len(), honest_votes.len());
 
         let mut participants = honest_participants.to_vec();
         participants.push(*dishonest_participant);
 
-        let mut protocols: Vec<(Participant, Box<dyn Protocol<Output = Vec<bool>>>)> =
+        let mut protocols: Vec<(_, Box<dyn Protocol<Output = Vec<bool>>>)> =
             Vec::with_capacity(participants.len());
 
         // we run the protocol for all honest parties

--- a/src/protocol/echo_broadcast.rs
+++ b/src/protocol/echo_broadcast.rs
@@ -90,7 +90,7 @@ where
     T: Serialize,
 {
     let vote = MessageType::Send(data);
-    let sid = participants.index(me);
+    let sid = participants.index(me)?;
     // Send vote to all participants but for myself
     chan.send_many(wait, &(&sid, &vote))?;
     // the vote is returned to be taken into consideration as received
@@ -133,7 +133,7 @@ where
 
     // receive simulated vote
     let mut from = *me;
-    let mut sid = participants.index(me);
+    let mut sid = participants.index(me)?;
     let mut vote = match send_vote {
         MessageType::Send(_) => send_vote.clone(),
         _ => {
@@ -169,7 +169,7 @@ where
                 // then skip
                 // the second condition prevents a malicious party starting the protocol
                 // on behalf on somebody else
-                if finish_send[sid] || sid != participants.index(&from) {
+                if finish_send[sid] || sid != participants.index(&from)? {
                     continue;
                 }
                 vote = MessageType::Echo(data);
@@ -272,7 +272,7 @@ where
 
                     // Output error if the received vote after broadcast is not
                     // the same as the one originally sent
-                    if sid == participants.index(me) && MessageType::Send(data) != send_vote {
+                    if sid == participants.index(me)? && MessageType::Send(data) != send_vote {
                         return Err(ProtocolError::AssertionFailed(
                             "Too many malicious parties, way above the assumed threshold:
                             The message output after the broadcast protocol is not the same as
@@ -384,7 +384,7 @@ mod test {
         me: Participant,
     ) -> Result<Vec<bool>, ProtocolError> {
         let wait_broadcast = chan.next_waitpoint();
-        let sid = participants.index(&me);
+        let sid = participants.index(&me)?;
 
         // malicious reliable broadcast send
         let vote_true = MessageType::Send(true);
@@ -411,7 +411,7 @@ mod test {
         me: Participant,
     ) -> Result<Vec<bool>, ProtocolError> {
         let wait_broadcast = chan.next_waitpoint();
-        let sid = participants.index(&me);
+        let sid = participants.index(&me)?;
 
         // malicious reliable broadcast send
         let vote_true = MessageType::Send(true);

--- a/src/protocol/echo_broadcast.rs
+++ b/src/protocol/echo_broadcast.rs
@@ -322,7 +322,7 @@ mod test {
     /// This function is similar to do_broadcast except it is tailored to
     /// consume the inputs instead of borrowing and become suitable for make_protocol
     /// function
-    pub async fn do_broadcast_consume(
+    async fn do_broadcast_consume(
         mut chan: SharedChannel,
         participants: ParticipantList,
         me: Participant,
@@ -338,7 +338,7 @@ mod test {
         Ok(vote_list)
     }
 
-    pub fn do_broadcast_honest(
+    fn do_broadcast_honest(
         participants: &[Participant],
         me: Participant,
         data: bool,
@@ -376,7 +376,7 @@ mod test {
         Ok(result)
     }
 
-    pub async fn do_broadcast_dishonest_consume_version_1(
+    async fn do_broadcast_dishonest_consume_version_1(
         mut chan: SharedChannel,
         participants: ParticipantList,
         me: Participant,
@@ -403,7 +403,7 @@ mod test {
         Ok(vote_list)
     }
 
-    pub async fn do_broadcast_dishonest_consume_version_2(
+    async fn do_broadcast_dishonest_consume_version_2(
         mut chan: SharedChannel,
         participants: ParticipantList,
         me: Participant,
@@ -430,7 +430,7 @@ mod test {
         Ok(vote_list)
     }
 
-    pub fn do_broadcast_dishonest_v1(
+    fn do_broadcast_dishonest_v1(
         participants: &[Participant],
         me: Participant,
     ) -> Result<impl Protocol<Output = Vec<bool>>, ProtocolError> {
@@ -450,7 +450,7 @@ mod test {
         Ok(make_protocol(comms, fut))
     }
 
-    pub fn do_broadcast_dishonest_v2(
+    fn do_broadcast_dishonest_v2(
         participants: &[Participant],
         me: Participant,
     ) -> Result<impl Protocol<Output = Vec<bool>>, ProtocolError> {


### PR DESCRIPTION
This PR prevents panic when searching for an index in ParticipantList and in ParticipantMap.

When I was trying to write unit test case by TrailOfBits in echo_broadcast.rs,
I couldn't help but improve the code readibility by reducing code redundancy in test cases