### PR TITLE
Use usize::midpoint to compute echo threshold safely

### DIFF
--- a/src/protocol/echo_broadcast.rs
+++ b/src/protocol/echo_broadcast.rs
@@ -73,7 +73,7 @@ fn echo_ready_thresholds(n: usize) -> (usize, usize) {
     }
     // we should always have n >= 3*threshold + 1
     let broadcast_threshold = (n - 1) / 3;
-    let echo_threshold = (n + broadcast_threshold) / 2;
+    let echo_threshold = usize::midpoint(n, broadcast_threshold);
     (echo_threshold, broadcast_threshold)
 }
 


### PR DESCRIPTION
Replace `(n + broadcast_threshold) / 2` with `usize::midpoint(n, broadcast_threshold)` to avoid **potential overflow** and clearly express intent. 
While overflow is extremely unlikely for realistic _participant_ counts, this change makes the calculation future-proof and self-documenting.

> Mathematically overflow in this code is possible: because the addition could exceed the maximum representable `usize`