### PR TITLE
chore: fix clippy issues, make test functions avoid using Result return

### DIFF
--- a/src/confidential_key_derivation/protocol.rs
+++ b/src/confidential_key_derivation/protocol.rs
@@ -182,7 +182,7 @@ fn compute_signature_share(
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::test::one_coordinator_output;
+    use crate::test::{one_coordinator_output, GenProtocol};
     use crate::{confidential_key_derivation::ciphersuite::hash_to_curve, protocol::run_protocol};
     use rand::Rng;
     use std::error::Error;
@@ -219,8 +219,7 @@ mod test {
         let index = rng.gen_range(0..participants.len());
         let coordinator = participants[index as usize];
 
-        let mut protocols: Vec<(Participant, Box<dyn Protocol<Output = CKDOutputOption>>)> =
-            Vec::with_capacity(participants.len());
+        let mut protocols: GenProtocol<CKDOutputOption> = Vec::with_capacity(participants.len());
 
         let mut private_shares = Vec::new();
         for p in &participants {

--- a/src/dkg.rs
+++ b/src/dkg.rs
@@ -670,7 +670,7 @@ pub mod test {
         <C::Group as Group>::Element: std::fmt::Debug + std::marker::Send,
         <<C::Group as Group>::Field as Field>::Scalar: std::marker::Send,
     {
-        let result = run_keygen::<C>(participants, threshold).unwrap();
+        let result = run_keygen::<C>(participants, threshold);
         assert!(result.len() == participants.len());
         assert_public_key_invariant(&result);
 
@@ -694,12 +694,12 @@ pub mod test {
         <C::Group as Group>::Element: std::fmt::Debug + std::marker::Send,
         <<C::Group as Group>::Field as Field>::Scalar: std::marker::Send,
     {
-        let result0 = run_keygen::<C>(participants, threshold).unwrap();
+        let result0 = run_keygen::<C>(participants, threshold);
         assert_public_key_invariant(&result0);
 
         let pub_key = result0[0].1.public_key.to_element();
 
-        let result1 = run_refresh(participants, &result0, threshold).unwrap();
+        let result1 = run_refresh(participants, &result0, threshold);
         assert_public_key_invariant(&result1);
 
         let participants = result1.iter().map(|p| p.0).collect::<Vec<_>>();
@@ -724,7 +724,7 @@ pub mod test {
         <C::Group as Group>::Element: std::fmt::Debug + std::marker::Send,
         <<C::Group as Group>::Field as Field>::Scalar: std::marker::Send,
     {
-        let result0 = run_keygen::<C>(participants, threshold0).unwrap();
+        let result0 = run_keygen::<C>(participants, threshold0);
         assert_public_key_invariant(&result0);
 
         let pub_key = result0[0].1.public_key;
@@ -738,8 +738,7 @@ pub mod test {
             threshold0,
             threshold1,
             &new_participant,
-        )
-        .unwrap();
+        );
         assert_public_key_invariant(&result1);
 
         let participants = result1.iter().map(|p| p.0).collect::<Vec<_>>();

--- a/src/ecdsa/ot_based_ecdsa/presign.rs
+++ b/src/ecdsa/ot_based_ecdsa/presign.rs
@@ -199,7 +199,7 @@ mod test {
     use crate::{
         ecdsa::{ot_based_ecdsa::triples::test::deal, KeygenOutput, Polynomial, ProjectivePoint},
         protocol::run_protocol,
-        test::generate_participants,
+        test::{generate_participants, GenProtocol},
     };
     use frost_secp256k1::{
         keys::{PublicKeyPackage, SigningShare},
@@ -221,9 +221,7 @@ mod test {
         let (triple0_pub, triple0_shares) = deal(&mut OsRng, &participants, original_threshold)?;
         let (triple1_pub, triple1_shares) = deal(&mut OsRng, &participants, original_threshold)?;
 
-        #[allow(clippy::type_complexity)]
-        let mut protocols: Vec<(Participant, Box<dyn Protocol<Output = PresignOutput>>)> =
-            Vec::with_capacity(participants.len());
+        let mut protocols: GenProtocol<PresignOutput> = Vec::with_capacity(participants.len());
 
         for ((p, triple0), triple1) in participants
             .iter()

--- a/src/ecdsa/ot_based_ecdsa/sign.rs
+++ b/src/ecdsa/ot_based_ecdsa/sign.rs
@@ -223,7 +223,7 @@ mod test {
             participants_presign.push((*p, presignature));
         }
 
-        let (_, sig) = run_sign_without_rerandomization(&participants_presign, public_key, msg)?;
+        let (_, sig) = run_sign_without_rerandomization(&participants_presign, public_key, msg);
         let sig = ecdsa::Signature::from_scalars(x_coordinate(&sig.big_r), sig.s)?;
         VerifyingKey::from(&PublicKey::from_affine(public_key.to_affine())?).verify(msg, &sig)?;
         Ok(())

--- a/src/ecdsa/ot_based_ecdsa/triples/multiplication.rs
+++ b/src/ecdsa/ot_based_ecdsa/triples/multiplication.rs
@@ -217,10 +217,8 @@ mod test {
     use crate::{
         crypto::hash::hash,
         participants::ParticipantList,
-        protocol::{
-            errors::ProtocolError, internal::make_protocol, run_protocol, Participant, Protocol,
-        },
-        test::generate_participants,
+        protocol::{errors::ProtocolError, internal::make_protocol, run_protocol},
+        test::{generate_participants, GenProtocol},
     };
 
     use super::multiplication;
@@ -242,8 +240,7 @@ mod test {
         let a = prep.iter().fold(Scalar::ZERO, |acc, (_, a_i, _)| acc + a_i);
         let b = prep.iter().fold(Scalar::ZERO, |acc, (_, _, b_i)| acc + b_i);
 
-        let mut protocols: Vec<(Participant, Box<dyn Protocol<Output = Scalar>>)> =
-            Vec::with_capacity(prep.len());
+        let mut protocols: GenProtocol<Scalar> = Vec::with_capacity(prep.len());
 
         let sid = hash(b"sid")?;
 
@@ -308,9 +305,7 @@ mod test {
                     .collect()
             });
 
-        #[allow(clippy::type_complexity)]
-        let mut protocols: Vec<(Participant, Box<dyn Protocol<Output = Vec<Scalar>>>)> =
-            Vec::with_capacity(prep.len());
+        let mut protocols: GenProtocol<Vec<Scalar>> = Vec::with_capacity(prep.len());
 
         let sids = (0..N)
             .map(|i| hash(&format!("sid{i}")))

--- a/src/ecdsa/robust_ecdsa/presign.rs
+++ b/src/ecdsa/robust_ecdsa/presign.rs
@@ -361,6 +361,7 @@ mod test {
     use super::*;
     use rand_core::OsRng;
 
+    use crate::test::GenProtocol;
     use crate::{ecdsa::KeygenOutput, protocol::run_protocol, test::generate_participants};
     use frost_secp256k1::keys::PublicKeyPackage;
     use frost_secp256k1::VerifyingKey;
@@ -378,8 +379,7 @@ mod test {
         let f = Polynomial::generate_polynomial(None, max_malicious, &mut OsRng)?;
         let big_x = ProjectivePoint::GENERATOR * f.eval_at_zero()?.0;
 
-        let mut protocols: Vec<(Participant, Box<dyn Protocol<Output = PresignOutput>>)> =
-            Vec::with_capacity(participants.len());
+        let mut protocols: GenProtocol<PresignOutput> = Vec::with_capacity(participants.len());
 
         for p in &participants {
             // simulating the key packages for each participant

--- a/src/ecdsa/robust_ecdsa/test.rs
+++ b/src/ecdsa/robust_ecdsa/test.rs
@@ -5,13 +5,13 @@ use super::{presign::presign, sign::sign, PresignArguments, PresignOutput};
 use crate::crypto::hash::test::scalar_hash_secp256k1;
 use crate::ecdsa::robust_ecdsa::RerandomizedPresignOutput;
 use crate::ecdsa::{
-    Element, KeygenOutput, ParticipantList, RerandomizationArguments, Secp256K1Sha256, Signature,
+    Element, ParticipantList, RerandomizationArguments, Secp256K1Sha256, Signature,
     SignatureOption, Tweak,
 };
 use crate::protocol::{run_protocol, Participant, Protocol};
 use crate::test::{
     assert_public_key_invariant, generate_participants, generate_participants_with_random_ids,
-    one_coordinator_output, run_keygen, run_refresh, run_reshare,
+    one_coordinator_output, run_keygen, run_refresh, run_reshare, GenOutput, GenProtocol,
 };
 
 use rand::rngs::OsRng;
@@ -114,11 +114,10 @@ pub fn run_sign_with_rerandomization(
 }
 
 pub fn run_presign(
-    participants: Vec<(Participant, KeygenOutput)>,
+    participants: GenOutput<Secp256K1Sha256>,
     max_malicious: usize,
-) -> Result<Vec<(Participant, PresignOutput)>, Box<dyn Error>> {
-    let mut protocols: Vec<(Participant, Box<dyn Protocol<Output = PresignOutput>>)> =
-        Vec::with_capacity(participants.len());
+) -> Vec<(Participant, PresignOutput)> {
+    let mut protocols: GenProtocol<PresignOutput> = Vec::with_capacity(participants.len());
 
     let participant_list: Vec<Participant> = participants.iter().map(|(p, _)| *p).collect();
 
@@ -131,13 +130,14 @@ pub fn run_presign(
                 threshold: max_malicious,
             },
             OsRng,
-        )?;
+        )
+        .unwrap();
         protocols.push((p, Box::new(protocol)));
     }
 
-    let mut result = run_protocol(protocols)?;
+    let mut result = run_protocol(protocols).unwrap();
     result.sort_by_key(|(p, _)| *p);
-    Ok(result)
+    result
 }
 
 #[test]
@@ -145,13 +145,13 @@ fn test_refresh() -> Result<(), Box<dyn Error>> {
     let participants = generate_participants(11);
     let max_malicious = 5;
     let threshold = max_malicious + 1;
-    let keys = run_keygen(&participants, threshold)?;
+    let keys = run_keygen(&participants, threshold);
     assert_public_key_invariant(&keys);
     // run refresh on these
-    let key_packages = run_refresh(&participants, &keys, threshold)?;
+    let key_packages = run_refresh(&participants, &keys, threshold);
     let public_key = key_packages[0].1.public_key;
     assert_public_key_invariant(&key_packages);
-    let presign_result = run_presign(key_packages, max_malicious)?;
+    let presign_result = run_presign(key_packages, max_malicious);
 
     let msg = b"hello world";
     run_sign_without_rerandomization(&presign_result, public_key.to_element(), msg)?;
@@ -166,7 +166,7 @@ fn test_reshare_sign_more_participants() -> Result<(), Box<dyn Error>> {
 
     let max_malicious = 3;
     let threshold = max_malicious + 1;
-    let result0 = run_keygen(&participants, threshold)?;
+    let result0 = run_keygen(&participants, threshold);
     assert_public_key_invariant(&result0);
 
     let pub_key = result0[2].1.public_key;
@@ -186,12 +186,12 @@ fn test_reshare_sign_more_participants() -> Result<(), Box<dyn Error>> {
         threshold,
         new_threshold,
         &new_participant,
-    )?;
+    );
     assert_public_key_invariant(&key_packages);
 
     let public_key = key_packages[0].1.public_key;
     // Presign
-    let presign_result = run_presign(key_packages, max_malicious)?;
+    let presign_result = run_presign(key_packages, max_malicious);
 
     let msg = b"hello world";
     run_sign_without_rerandomization(&presign_result, public_key.to_element(), msg)?;
@@ -205,7 +205,7 @@ fn test_reshare_sign_less_participants() -> Result<(), Box<dyn Error>> {
 
     let max_malicious = 2;
     let threshold = max_malicious + 1;
-    let result0 = run_keygen(&participants, threshold)?;
+    let result0 = run_keygen(&participants, threshold);
     assert_public_key_invariant(&result0);
 
     let pub_key = result0[2].1.public_key;
@@ -222,11 +222,11 @@ fn test_reshare_sign_less_participants() -> Result<(), Box<dyn Error>> {
         threshold,
         new_threshold,
         &new_participant,
-    )?;
+    );
     assert_public_key_invariant(&key_packages);
     let public_key = key_packages[0].1.public_key;
     // Presign
-    let presign_result = run_presign(key_packages, max_malicious)?;
+    let presign_result = run_presign(key_packages, max_malicious);
 
     let msg = b"hello world";
     run_sign_without_rerandomization(&presign_result, public_key.to_element(), msg)?;
@@ -238,11 +238,11 @@ fn test_e2e() -> Result<(), Box<dyn Error>> {
     let participants = generate_participants(8);
     let max_malicious = 3;
 
-    let keygen_result = run_keygen(&participants, max_malicious + 1)?;
+    let keygen_result = run_keygen(&participants, max_malicious + 1);
 
     let public_key = keygen_result[0].1.public_key;
     assert_public_key_invariant(&keygen_result);
-    let presign_result = run_presign(keygen_result, max_malicious)?;
+    let presign_result = run_presign(keygen_result, max_malicious);
 
     let msg = b"hello world";
     run_sign_without_rerandomization(&presign_result, public_key.to_element(), msg)?;
@@ -255,12 +255,12 @@ fn test_e2e_random_identifiers() -> Result<(), Box<dyn Error>> {
     let participants = generate_participants_with_random_ids(participants_count, &mut OsRng);
     let max_malicious = 3;
 
-    let keygen_result = run_keygen(&participants, max_malicious + 1)?;
+    let keygen_result = run_keygen(&participants, max_malicious + 1);
     assert_public_key_invariant(&keygen_result);
 
     let public_key = keygen_result[0].1.public_key;
     assert_public_key_invariant(&keygen_result);
-    let presign_result = run_presign(keygen_result, max_malicious)?;
+    let presign_result = run_presign(keygen_result, max_malicious);
 
     let msg = b"hello world";
     run_sign_without_rerandomization(&presign_result, public_key.to_element(), msg)?;
@@ -273,12 +273,12 @@ fn test_e2e_random_identifiers_with_rerandomization() -> Result<(), Box<dyn Erro
     let participants = generate_participants_with_random_ids(participants_count, &mut OsRng);
     let max_malicious = 3;
 
-    let keygen_result = run_keygen(&participants, max_malicious + 1)?;
+    let keygen_result = run_keygen(&participants, max_malicious + 1);
     assert_public_key_invariant(&keygen_result);
 
     let public_key = keygen_result[0].1.public_key;
     assert_public_key_invariant(&keygen_result);
-    let presign_result = run_presign(keygen_result, max_malicious)?;
+    let presign_result = run_presign(keygen_result, max_malicious);
 
     let msg = b"hello world";
     run_sign_with_rerandomization(&presign_result, public_key.to_element(), msg)?;
@@ -305,7 +305,7 @@ where
     let mut participants = generate_participants_with_random_ids(participants_count, &mut OsRng);
     let max_malicious = 4;
 
-    let mut keygen_result = run_keygen(&participants.clone(), max_malicious + 1)?;
+    let mut keygen_result = run_keygen(&participants.clone(), max_malicious + 1);
     assert_public_key_invariant(&keygen_result);
 
     // Now remove a participant
@@ -315,7 +315,7 @@ where
 
     let public_key = keygen_result[0].1.public_key;
     assert_public_key_invariant(&keygen_result);
-    let mut presign_result = run_presign(keygen_result, max_malicious)?;
+    let mut presign_result = run_presign(keygen_result, max_malicious);
 
     // Use less presignatures to sign
     presign_result.remove(0);

--- a/src/eddsa/sign.rs
+++ b/src/eddsa/sign.rs
@@ -376,7 +376,7 @@ mod test {
         let msg_hash = hash(&msg)?;
 
         // test dkg
-        let key_packages = run_keygen(&participants, threshold)?;
+        let key_packages = run_keygen(&participants, threshold);
         assert_public_key_invariant(&key_packages);
         let coordinators = vec![key_packages[0].0];
         let data = test_run_signature_protocols(
@@ -395,7 +395,7 @@ mod test {
             .is_ok());
 
         // // test refresh
-        let key_packages1 = run_refresh(&participants, &key_packages, threshold)?;
+        let key_packages1 = run_refresh(&participants, &key_packages, threshold);
         assert_public_key_invariant(&key_packages1);
         let msg = "hello_near_2";
         let msg_hash = hash(&msg)?;
@@ -425,7 +425,7 @@ mod test {
             threshold,
             new_threshold,
             &new_participant,
-        )?;
+        );
         assert_public_key_invariant(&key_packages2);
         let msg = "hello_near_3";
         let msg_hash = hash(&msg)?;
@@ -451,7 +451,7 @@ mod test {
     fn test_reshare_sign_more_participants() -> Result<(), Box<dyn Error>> {
         let participants = generate_participants(5);
         let threshold = 3;
-        let result0 = run_keygen(&participants, threshold)?;
+        let result0 = run_keygen(&participants, threshold);
         assert_public_key_invariant(&result0);
 
         let pub_key = result0[2].1.public_key;
@@ -469,7 +469,7 @@ mod test {
             threshold,
             new_threshold,
             &new_participant,
-        )?;
+        );
         assert_public_key_invariant(&key_packages);
 
         let participants: Vec<_> = key_packages
@@ -517,7 +517,7 @@ mod test {
     fn test_reshare_sign_less_participants() -> Result<(), Box<dyn Error>> {
         let participants = generate_participants(5);
         let threshold = 4;
-        let result0 = run_keygen(&participants, threshold)?;
+        let result0 = run_keygen(&participants, threshold);
         assert_public_key_invariant(&result0);
         let coordinators = vec![result0[0].0];
 
@@ -534,7 +534,7 @@ mod test {
             threshold,
             new_threshold,
             &new_participant,
-        )?;
+        );
         assert_public_key_invariant(&key_packages);
 
         let participants: Vec<_> = key_packages

--- a/src/eddsa/test.rs
+++ b/src/eddsa/test.rs
@@ -1,9 +1,9 @@
 use crate::crypto::hash::HashOutput;
 use crate::eddsa::{sign::sign, KeygenOutput, SignatureOption};
 use crate::participants::ParticipantList;
-use crate::protocol::{run_protocol, Participant, Protocol};
-use crate::test::generate_participants;
+use crate::protocol::{run_protocol, Participant};
 use crate::test::MockCryptoRng;
+use crate::test::{generate_participants, GenOutput, GenProtocol};
 
 use frost_core::keys::SigningShare;
 use frost_core::VerifyingKey as FrostVerifyingKey;
@@ -11,15 +11,11 @@ use frost_core::{Scalar as FrostScalar, SigningKey as FrostSigningKey};
 use frost_ed25519::Ed25519Sha512;
 
 type C = Ed25519Sha512;
-
 use rand_core::{OsRng, RngCore};
 use std::error::Error;
 
 /// this is a centralized key generation
-pub fn build_key_packages_with_dealer(
-    max_signers: u16,
-    min_signers: u16,
-) -> Vec<(Participant, KeygenOutput)> {
+pub fn build_key_packages_with_dealer(max_signers: u16, min_signers: u16) -> GenOutput<C> {
     use std::collections::BTreeMap;
 
     let mut identifiers = Vec::with_capacity(max_signers.into());
@@ -64,8 +60,7 @@ pub fn test_run_signature_protocols(
     threshold: usize,
     msg_hash: HashOutput,
 ) -> Result<Vec<(Participant, SignatureOption)>, Box<dyn Error>> {
-    let mut protocols: Vec<(Participant, Box<dyn Protocol<Output = SignatureOption>>)> =
-        Vec::with_capacity(participants.len());
+    let mut protocols: GenProtocol<SignatureOption> = Vec::with_capacity(participants.len());
 
     let participants_list = participants
         .iter()

--- a/tests/ckd.rs
+++ b/tests/ckd.rs
@@ -9,8 +9,10 @@ use threshold_signatures::{
         protocol::ckd,
         AppId, CKDOutputOption,
     },
-    protocol::{run_protocol, Participant, Protocol},
+    protocol::run_protocol,
 };
+
+use crate::common::GenProtocol;
 type C = threshold_signatures::confidential_key_derivation::BLS12381SHA256;
 type Scalar = threshold_signatures::Scalar<C>;
 
@@ -35,8 +37,7 @@ fn test_ckd() {
 
     let coordinator = choose_coordinator_at_random(&participants);
 
-    let mut protocols: Vec<(Participant, Box<dyn Protocol<Output = CKDOutputOption>>)> =
-        Vec::with_capacity(participants.len());
+    let mut protocols: GenProtocol<CKDOutputOption> = Vec::with_capacity(participants.len());
 
     for p in &participants {
         let private_share = result.get(p).unwrap().private_share;

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -9,7 +9,7 @@ use threshold_signatures::{
     Ciphersuite, Element, KeygenOutput, Scalar,
 };
 
-type GenProtocol<C> = Vec<(Participant, Box<dyn Protocol<Output = KeygenOutput<C>>>)>;
+pub type GenProtocol<C> = Vec<(Participant, Box<dyn Protocol<Output = C>>)>;
 
 pub fn generate_participants(number: u32) -> Vec<Participant> {
     (0..number).map(Participant::from).collect::<Vec<_>>()
@@ -29,7 +29,7 @@ where
     Element<C>: std::marker::Send,
     Scalar<C>: std::marker::Send,
 {
-    let protocols: GenProtocol<C> = participants
+    let protocols: GenProtocol<KeygenOutput<C>> = participants
         .iter()
         .map(|p| {
             let protocol: Box<dyn Protocol<Output = KeygenOutput<C>>> =

--- a/tests/eddsa.rs
+++ b/tests/eddsa.rs
@@ -7,8 +7,10 @@ use rand_core::OsRng;
 use threshold_signatures::{
     self,
     eddsa::{sign::sign, Ed25519Sha512, SignatureOption},
-    protocol::{run_protocol, Participant, Protocol},
+    protocol::{run_protocol, Participant},
 };
+
+use crate::common::GenProtocol;
 
 type C = Ed25519Sha512;
 type KeygenOutput = threshold_signatures::KeygenOutput<C>;
@@ -19,8 +21,7 @@ fn run_sign(
     coordinator: Participant,
     msg_hash: &[u8],
 ) -> Vec<(Participant, SignatureOption)> {
-    let mut protocols: Vec<(Participant, Box<dyn Protocol<Output = SignatureOption>>)> =
-        Vec::with_capacity(participants.len());
+    let mut protocols: GenProtocol<SignatureOption> = Vec::with_capacity(participants.len());
 
     let participants_list: Vec<Participant> = participants.iter().map(|(p, _)| *p).collect();
     for (p, keygen_output) in participants {

--- a/tests/robust_ecdsa.rs
+++ b/tests/robust_ecdsa.rs
@@ -15,12 +15,14 @@ use threshold_signatures::{
         RerandomizationArguments, Secp256K1Sha256, Signature, SignatureOption,
     },
     frost_secp256k1::VerifyingKey,
-    protocol::{run_protocol, Participant, Protocol},
+    protocol::{run_protocol, Participant},
     Element, ParticipantList,
 };
 
 // TODO: This is required to use Scalar::from_repr
 use elliptic_curve::ff::PrimeField;
+
+use crate::common::GenProtocol;
 
 type C = Secp256K1Sha256;
 type KeygenOutput = threshold_signatures::KeygenOutput<C>;
@@ -31,8 +33,7 @@ fn run_presign(
     participants: HashMap<Participant, KeygenOutput>,
     max_malicious: usize,
 ) -> Vec<(Participant, PresignOutput)> {
-    let mut protocols: Vec<(Participant, Box<dyn Protocol<Output = PresignOutput>>)> =
-        Vec::with_capacity(participants.len());
+    let mut protocols: GenProtocol<PresignOutput> = Vec::with_capacity(participants.len());
 
     let participant_list: Vec<Participant> = participants.keys().copied().collect();
 
@@ -63,7 +64,7 @@ fn run_sign(
         .into_option()
         .expect("Couldn't construct k256 point");
 
-    let mut protocols: Vec<(Participant, Box<dyn Protocol<Output = SignatureOption>>)> =
+    let mut protocols: GenProtocol<SignatureOption> =
         Vec::with_capacity(participants_presign.len());
 
     let participants: Vec<Participant> = participants_presign.iter().map(|(p, _)| *p).collect();


### PR DESCRIPTION
Closes #12 

I used the opportunity to fix many test function return values of type `Result<T, Error>`, therefore the PR is a bit bigger than expected.