### PR TITLE
chore: add action to add issues to project automatically

### DIFF
--- a/.github/workflows/add-new-issues-to-project.yml
+++ b/.github/workflows/add-new-issues-to-project.yml
@@ -9,6 +9,8 @@ jobs:
   add-to-project:
     name: Add issue to project
     runs-on: ubuntu-latest
+    permissions:
+        issues: read
     steps:
       - uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
         with:


### PR DESCRIPTION
Closes #202 

- Notice we cannot test this until after it is merged (but I tested in another repo)
- I am using a token I generated, it would be better to use one from the organization. The change does not affect the PR, just the config in github
- This cannot verify who opened the issue. If we face any kind of DoS, we will need to disable it