### PR TITLE
Changing fixed outputs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1426,6 +1426,7 @@ dependencies = [
  "k256",
  "keccak",
  "rand",
+ "rand_chacha",
  "rand_core",
  "rmp-serde",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,8 @@ k256 = { version = "0.13.4", default-features = false, features = [
 ] }
 keccak = "0.1.5"
 rand = { version = "0.8.5", optional = true }
+# This one cannot be upgraded to remain compatible with rand_core (although used only in test cases)
+rand_chacha = {version = "0.3.1", optional = true}
 # This one cannot be upgraded to remain compatible with frost-core
 rand_core = { version = "0.6.4" }
 rmp-serde = "1.3.0"
@@ -51,7 +53,7 @@ zeroize = "1.8.2"
 [features]
 default = ["actively_secure_robust_ecdsa"]
 actively_secure_robust_ecdsa = []
-test-utils = ["rand"]
+test-utils = ["rand", "rand_chacha"]
 
 [dev-dependencies]
 criterion = {version = "0.7.0", features = ["html_reports"]}

--- a/src/crypto/proofs/dlog.rs
+++ b/src/crypto/proofs/dlog.rs
@@ -163,7 +163,7 @@ mod test {
 
     #[test]
     fn test_prove_fixed_randomness() {
-        let mut rng = MockCryptoRng::new(&[1; 8]);
+        let mut rng = MockCryptoRng::seed_from_u64(42u64);
         let x = Scalar::generate_biased(&mut rng);
 
         let statement = Statement::<Secp256K1Sha256> {
@@ -184,13 +184,13 @@ mod test {
         .unwrap();
         assert_eq!(
             Scalar::from_uint_unchecked(Uint::from_be_hex(
-                "0AD3DBF5B730B6DBF3B76F75E0160F409D08B9588F1C1F09DBA8BA629F9CFFD2"
+                "2CA2176C16DAF45BCCD2BB89797FB29EA634A9E8FF0DA8B5F207AA09EEC856B0"
             )),
             proof.s.0
         );
         assert_eq!(
             Scalar::from_uint_unchecked(Uint::from_be_hex(
-                "4AD88D4379E35C0C959A6591289DE20B39ABF1C5FE48BE0F2F6EA2EFBABFC3E1"
+                "198698C0362CAC8A89F873F691FC65A7E24006F4544BF2A21AFF79C86A64F561"
             )),
             proof.e.0
         );

--- a/src/crypto/proofs/dlogeq.rs
+++ b/src/crypto/proofs/dlogeq.rs
@@ -236,7 +236,7 @@ mod test {
 
     #[test]
     fn test_prove_fixed_randomness() {
-        let mut rng = MockCryptoRng::new(&[1; 8]);
+        let mut rng = MockCryptoRng::seed_from_u64(42u64);
         let x = Scalar::generate_biased(&mut rng);
         let h = Scalar::generate_biased(&mut rng);
         let big_h = ProjectivePoint::GENERATOR * h;
@@ -261,13 +261,13 @@ mod test {
         .unwrap();
         assert_eq!(
             Scalar::from_uint_unchecked(Uint::from_be_hex(
-                "F71D2F355A0905A88437576D0D2C02337DF5D72B68AF54C4843B06A3D66AB0B3"
+                "0D5982BE2922D4BF893BFA4F0086C59738CA1F77BCA4316F28F263E2F1347C21"
             )),
             proof.s.0
         );
         assert_eq!(
             Scalar::from_uint_unchecked(Uint::from_be_hex(
-                "4DF85F7ADB8B0A27F9C60086BC0801A3B92877F6A5E961BF792C3BBF9676619D"
+                "2912F8772B0E33708AD3A3F8A587FCBE23A50109496F4A3F8669979F2B78AEFD"
             )),
             proof.e.0
         );

--- a/src/ecdsa/mod.rs
+++ b/src/ecdsa/mod.rs
@@ -245,7 +245,7 @@ mod test {
     #[test]
     fn keygen_output_should_be_serializable() {
         // Given
-        let mut rng = MockCryptoRng::new(&[1; 8]);
+        let mut rng = MockCryptoRng::seed_from_u64(42u64);
         let signing_key = FrostSigningKey::<C>::new(&mut rng);
 
         let keygen_output = KeygenOutput {
@@ -260,7 +260,7 @@ mod test {
         // Then
         assert_eq!(
             serialized_keygen_output,
-            "{\"private_share\":\"0000000000000000000000000000000000000000000000000000000000000001\",\"public_key\":\"02367fd00d5d124aafa1174e1250cdd6fd8ea2c81b16bec0689cba9f5abd15194b\"}"
+            "{\"private_share\":\"0000000000000000000000000000000000000000000000000000000000000001\",\"public_key\":\"0351177dde89242d9121d787a681bd2a0bd6013428a6b83e684a253815db96d8b3\"}"
         );
     }
 

--- a/src/eddsa/test.rs
+++ b/src/eddsa/test.rs
@@ -107,7 +107,7 @@ pub fn test_run_signature_protocols(
 #[allow(non_snake_case)]
 fn keygen_output__should_be_serializable() {
     // Given
-    let mut rng = MockCryptoRng::new(&[1; 8]);
+    let mut rng = MockCryptoRng::seed_from_u64(42u64);
     let signing_key = FrostSigningKey::<C>::new(&mut rng);
 
     let keygen_output = KeygenOutput {
@@ -122,7 +122,7 @@ fn keygen_output__should_be_serializable() {
     // Then
     assert_eq!(
         serialized_keygen_output,
-        "{\"private_share\":\"0700000000000000000000000000000000000000000000000000000000000000\",\"public_key\":\"91ad35c85df5aa2a9fd55a545a9c80673d62e33a07710dfe5e5333da9bb48e38\"}"
+        "{\"private_share\":\"0700000000000000000000000000000000000000000000000000000000000000\",\"public_key\":\"a80ed62da91a8c6f266d82c4b2017cc0be13e6acba26af04494635b15ac86b57\"}"
     );
 }
 


### PR DESCRIPTION
Closes #213 - the output is not a Sha256 hash but a chacha output
Partially fixes #107 - for improving the MockCryptoRng
Idea is to improve the MockCryptoRng to be tested and used properly in the Snapshot bench. 