### PR TITLE
[1/4] Document threshold policies and security assumptions

### DIFF
--- a/docs/threshold_policies.md
+++ b/docs/threshold_policies.md
@@ -70,8 +70,7 @@ Keep `f` explicit even when `t = f + 1`. The current schemes tie `t` to `f`, but
 
 # Refresh & Resharing Safety
 
-- Never change thresholds during refresh/resharing. Doing so breaks the assumptions of all supported schemes.
-- To adopt a new threshold: **Perform a new DKG**, archive the old key, and migrate intentionally.
+- Thresholds must *not* be changed during refresh/resharing unless explicitly permitted by `SchemeRules`. Unsanctioned changes break the assumptions of all supported schemes.
 - Threshold metadata must always be persisted together with key/share identifiers.
 
 ---


### PR DESCRIPTION
related to #18 
related to #57 

---

> **Part 1/4**: Document threshold semantics and security assumptions across schemes

[Part 2/4](https://github.com/near/threshold-signatures/pull/222): Persist and enforce threshold invariants across key refresh APIs
Part 3/4: Implement scheme-specific hardcoded threshold validation
Part 4/4: Mirror threshold validation and checks in MPC repo