### PR TITLE
chore: document that threshold should stay the same during refresh

### DIFF
--- a/src/crypto/polynomials.rs
+++ b/src/crypto/polynomials.rs
@@ -42,7 +42,7 @@ impl<C: Ciphersuite> Polynomial<C> {
         })
     }
 
-    /// Returns the coeficients of the polynomial
+    /// Returns the coefficients of the polynomial
     pub fn get_coefficients(&self) -> Vec<Scalar<C>> {
         self.coefficients.clone()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,7 +154,7 @@ where
     }
     let comms = Comms::new();
     // NOTE: this equality must be kept, as changing the threshold during `key refresh`
-    // might lead to insecure scenarios. For more information see https://github.com/near/threshold-signatures/security/dependabot/3
+    // might lead to insecure scenarios. For more information see https://github.com/ZcashFoundation/frost/security/advisories/GHSA-wgq8-vr6r-mqxm
     let threshold = old_threshold;
     let (participants, old_participants) = reshare_assertions::<C>(
         old_participants,


### PR DESCRIPTION
Closes #57 

- After reading carefully the auditor's advice, and the [original fix](https://github.com/ZcashFoundation/frost/pull/908/files) for a similar problem in frost, I think the only thing we can do here is adding a comment for future developers, as the current implementation already guarantees the invariant.