### PR TITLE
chore: make indexing-slicing rule local

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,11 +111,8 @@ many-single-char-names = "allow"
 must-use-candidate = "allow"
 return-self-not-must-use = "allow"
 
-# TODO: this also hit too many cases https://github.com/near/threshold-signatures/issues/122
-# should be removed
-indexing-slicing = "allow"
-
 # Part of clippy restriction group
+indexing-slicing = "deny"
 panic = "deny"
 panic-in-result-fn = "warn"
 unwrap-used = "warn"

--- a/benches/advanced_ot_based_ecdsa.rs
+++ b/benches/advanced_ot_based_ecdsa.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::indexing_slicing)]
+
 use criterion::{criterion_group, Criterion};
 use frost_secp256k1::VerifyingKey;
 use rand::{Rng, RngCore};

--- a/benches/advanced_robust_ecdsa.rs
+++ b/benches/advanced_robust_ecdsa.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::indexing_slicing)]
+
 use criterion::{criterion_group, Criterion};
 use frost_secp256k1::VerifyingKey;
 use rand::{Rng, RngCore};

--- a/benches/bench_utils.rs
+++ b/benches/bench_utils.rs
@@ -1,5 +1,5 @@
-#![allow(dead_code)]
-#![allow(clippy::missing_panics_doc)]
+#![allow(dead_code, clippy::missing_panics_doc, clippy::indexing_slicing)]
+
 use frost_secp256k1::VerifyingKey;
 use k256::AffinePoint;
 use rand::Rng;

--- a/benches/naive_ot_based_ecdsa.rs
+++ b/benches/naive_ot_based_ecdsa.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::indexing_slicing)]
+
 use criterion::{criterion_group, Criterion};
 mod bench_utils;
 use crate::bench_utils::{

--- a/benches/naive_robust_ecdsa.rs
+++ b/benches/naive_robust_ecdsa.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::indexing_slicing)]
+
 use criterion::{criterion_group, Criterion};
 mod bench_utils;
 use crate::bench_utils::{robust_ecdsa_prepare_presign, robust_ecdsa_prepare_sign, MAX_MALICIOUS};

--- a/src/crypto/polynomials.rs
+++ b/src/crypto/polynomials.rs
@@ -1,3 +1,6 @@
+// # TODO(#122): remove this exception
+#![allow(clippy::indexing_slicing)]
+
 use frost_core::{
     keys::CoefficientCommitment, serialization::SerializableScalar, Field, Group, Scalar,
 };
@@ -9,7 +12,7 @@ use crate::{errors::ProtocolError, participants::Participant};
 
 use serde::{Deserialize, Deserializer, Serialize};
 
-/// Polynomial structure of non-empty or non-zero coefficiants
+/// Polynomial structure of non-empty or non-zero coefficients
 /// Represents a polynomial with coefficients in the scalar field of the curve.
 pub struct Polynomial<C: Ciphersuite> {
     /// The coefficients of our polynomial,

--- a/src/crypto/proofs/strobe.rs
+++ b/src/crypto/proofs/strobe.rs
@@ -5,6 +5,9 @@
 
 //! Minimal implementation of (parts of) Strobe.
 
+// # TODO(#122): remove this exception
+#![allow(clippy::indexing_slicing)]
+
 use derive_more::{Deref, DerefMut};
 use zeroize::Zeroize;
 

--- a/src/ecdsa/mod.rs
+++ b/src/ecdsa/mod.rs
@@ -1,4 +1,8 @@
 //! This module serves as a wrapper for ECDSA scheme.
+
+// # TODO(#122): remove this exception
+#![allow(clippy::indexing_slicing)]
+
 pub mod ot_based_ecdsa;
 pub mod robust_ecdsa;
 

--- a/src/participants.rs
+++ b/src/participants.rs
@@ -4,6 +4,9 @@
 //! or getting the field values corresponding to each participant, etc.
 //! This module tries to provide useful data structures for doing that.
 
+// # TODO(#122): remove this exception
+#![allow(clippy::indexing_slicing)]
+
 use std::collections::HashMap;
 
 use frost_core::serialization::SerializableScalar;

--- a/src/protocol/echo_broadcast.rs
+++ b/src/protocol/echo_broadcast.rs
@@ -1,3 +1,6 @@
+// # TODO(#122): remove this exception
+#![allow(clippy::indexing_slicing)]
+
 use crate::participants::{ParticipantCounter, ParticipantList, ParticipantMap};
 use crate::protocol::ProtocolError;
 use crate::protocol::{

--- a/src/protocol/internal.rs
+++ b/src/protocol/internal.rs
@@ -41,6 +41,10 @@
 //! agree on what the identifier for the channels in each part of the protocol is.
 //! This is why we have to take great care that the identifiers a protocol will produce
 //! are deterministic, even in the presence of concurrent tasks.
+
+// # TODO(#122): remove this exception
+#![allow(clippy::indexing_slicing)]
+
 use super::{Action, MessageData, Participant, Protocol, ProtocolError};
 use futures::future::BoxFuture;
 use futures::lock::Mutex;

--- a/src/test_utils/mod.rs
+++ b/src/test_utils/mod.rs
@@ -2,7 +2,8 @@
     clippy::panic,
     clippy::missing_panics_doc,
     clippy::unwrap_used,
-    clippy::cast_possible_truncation
+    clippy::cast_possible_truncation,
+    clippy::indexing_slicing
 )]
 
 mod dkg;

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,4 +1,5 @@
-#![allow(clippy::unwrap_used)]
+#![allow(clippy::unwrap_used, clippy::indexing_slicing)]
+
 use std::collections::HashMap;
 
 use rand::Rng;

--- a/tests/robust_ecdsa.rs
+++ b/tests/robust_ecdsa.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::unwrap_used)]
+#![allow(clippy::unwrap_used, clippy::indexing_slicing)]
 mod common;
 
 use common::{choose_coordinator_at_random, generate_participants, run_keygen};


### PR DESCRIPTION
Closes #259 

- The only places where we allow index slicing is in tests or bench code. Everywhere else, a TODO with the corresponding issue was added.