### PR TITLE
Deleting the usage of one function

### DIFF
--- a/src/eddsa/sign.rs
+++ b/src/eddsa/sign.rs
@@ -349,7 +349,7 @@ mod test {
                     msg_hash,
                 )
                 .unwrap();
-            one_coordinator_output(data, coordinators[0]).unwrap();
+                one_coordinator_output(data, coordinators[0]).unwrap();
             }
         }
     }


### PR DESCRIPTION
I noticed in the EdDSA testing we make use of a function that is already implemented in the test_utils.
I got rid of that redundancy.