### PR TITLE
fix: CI failure in main caused by dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,6 @@ updates:
 
     cooldown:
       default-days: 7
-      days: 7
 
     groups:
       rust-dependencies:


### PR DESCRIPTION
Fixes CI in main, follow-up to #286 